### PR TITLE
fix: Minimal Buttons borderless

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -88,10 +88,12 @@
 
     &[class*='minimal'] {
       background-color: transparent;
+      border: none;
       box-shadow: none;
       color: var(--primary-7);
       &:hover {
         background-color: transparent;
+        box-shadow: var(--button-shadow);
       }
 
       &:not(.without-shadow) {
@@ -126,6 +128,7 @@
 
       &[class*='minimal'] {
         border: none;
+        box-shadow: none;
         color: var(--primary-7);
         background: none;
       }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, Button as BButton, IButtonProps } from '@blueprintjs/core'
+import { AnchorButton, Button as BButton, IButtonProps, Intent } from '@blueprintjs/core'
 import cx from 'classnames'
 import React, { ElementType, HTMLAttributes, MouseEvent, useState } from 'react'
 import { Assign } from 'utility-types'
@@ -115,7 +115,7 @@ export function Button(props: ButtonProps): React.ReactElement {
         [css.round]: round,
         [css.iconOnly]: !props.text && !props.intent && !props.href,
         [css.link]: props.href && !(props.icon || props.rightIcon) && !props.intent,
-        [css['without-shadow']]: props.withoutBoxShadow
+        [css['without-shadow']]: props.withoutBoxShadow || props.minimal
       })}
     />
   )


### PR DESCRIPTION
Minimal buttons to have no box shadows and disabled minimal buttons to have no borders

<img width="511" alt="Screenshot 2021-04-30 at 3 47 29 PM" src="https://user-images.githubusercontent.com/67941036/116682628-1bd07180-a9cc-11eb-86ad-e21d3a8253a0.png">
<img width="1008" alt="Screenshot 2021-04-30 at 3 47 17 PM" src="https://user-images.githubusercontent.com/67941036/116682621-1a06ae00-a9cc-11eb-9a0c-3d19cfa7a5ee.png">
