### PR TITLE
fix: Allow clearing value in MultiTypeSelect on clear button

### DIFF
--- a/src/components/FormikForm/FormikForm.stories.tsx
+++ b/src/components/FormikForm/FormikForm.stories.tsx
@@ -140,6 +140,16 @@ export const Basic: Story<FormikFormProps> = () => (
                 { label: 'Software Engineer', value: 'SE' },
                 { label: 'Quality Engineer', value: 'QE' }
               ]}
+              useValue
+              multiTypeInputProps={{
+                selectProps: {
+                  addClearBtn: true,
+                  items: [
+                    { label: 'Software Engineer', value: 'SE' },
+                    { label: 'Quality Engineer', value: 'QE' }
+                  ]
+                }
+              }}
             />
             <FormInput.MultiTextInput name="jobDesc1" label="Job Desc 1" />
             <FormInput.MultiTextInput name="jobDec2" placeholder="Job Desc" label="Job Desc 2" />

--- a/src/components/FormikForm/FormikForm.tsx
+++ b/src/components/FormikForm/FormikForm.tsx
@@ -932,6 +932,8 @@ const FormMultiTypeInput = (props: FormMultiTypeInputProps & FormikContextProps<
         label: formikValue,
         value: formikValue
       }
+    } else if (isNil(value)) {
+      value = ''
     }
   }
   const autoComplete = props.autoComplete || getDefaultAutoCompleteValue()


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
