### PR TITLE
fix: [PL-14824]: UI hitting enter  issue

### DIFF
--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useIsMounted } from '../../hooks/useIsMounted'
 import { Container } from '../Container/Container'
 import { Text } from '../Text/Text'
+import { Utils } from '../../core/Utils'
 import css from './TagInput.css'
 import i18nBase from './TagInput.i18n'
 
@@ -280,6 +281,11 @@ export function TagInput<T>(props: TagInputProps<T>) {
           const _selectedItems = selectedItems.filter((_item, _index) => _index !== index)
           setSelectedItems(_selectedItems)
           onChange?.(_selectedItems, createdItems, items)
+        },
+        onKeyDown: (event: React.KeyboardEvent) => {
+          if (event.keyCode === 13) {
+            Utils.stopEvent(event)
+          }
         },
         rightElement: loading ? SPINNER : clearButton,
         tagProps: _getTagProps,


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`

Problem :- UI- Hitting Enter on Create Connector form takes me to next step

![122525403-d24cec00-d036-11eb-808e-ca4585749e96](https://user-images.githubusercontent.com/79828424/122705957-5d66f580-d274-11eb-91e1-c47be61dbf42.png)
