### PR TITLE
fix: Don't call onchange on mount of expression input

### DIFF
--- a/src/components/ExpressionInput/ExpressionInput.tsx
+++ b/src/components/ExpressionInput/ExpressionInput.tsx
@@ -38,6 +38,7 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
     disabled,
     autoComplete = 'off'
   } = props
+  const mountRef = React.useRef(false)
   /**
    * This holds the complete value of the input
    */
@@ -79,7 +80,11 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
   }, [queryValue])
 
   React.useEffect(() => {
-    onChange(inputValue)
+    if (mountRef.current) {
+      onChange(inputValue)
+    } else {
+      mountRef.current = true
+    }
   }, [inputValue])
 
   function resetQuery(): void {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
