### PR TITLE
chore: Adjusted the accordion css as per the latest UX

### DIFF
--- a/src/components/Accordion/Accordion.css
+++ b/src/components/Accordion/Accordion.css
@@ -4,10 +4,10 @@
 }
 
 .panel:first-child {
-  padding-top: 24px;
+  padding-top: var(--spacing-xlarge);
 }
 .panel:last-child {
-  padding-bottom: 24px;
+  padding-bottom: var(--spacing-xlarge);
 }
 
 .panel {
@@ -25,14 +25,14 @@
 
     .label {
       font-weight: 600;
-      font-size: 14px;
+      font-size: var(--font-size-normal);
       color: var(--black);
       padding-left: var(--spacing-medium) !important;
     }
   }
 
   .chevron {
-    width: 12px;
+    width: var(--spacing-4);
     height: 6px;
     position: relative;
     color: var(--primary-7);
@@ -83,6 +83,6 @@
   }
 
   .details {
-    padding: 12px 0 var(--spacing-large) 0;
+    padding: var(--spacing-4) 0 var(--spacing-large) 0;
   }
 }


### PR DESCRIPTION
Changed the CSS of accordions as per the latest UX guidelines. See here - https://www.figma.com/file/bYQtU9kWVuVEsLksbVgGM4/hex2o?node-id=9033%3A0

Addressed-
1. Gap within two accordion panels
2. Additional padding for first and last accordions
3. Label size and color changes

Before -
![Screenshot 2021-07-12 at 4 58 50 PM](https://user-images.githubusercontent.com/49017057/125280259-770ad280-e332-11eb-8aa1-2dcef73c5713.png)



After -
![Screenshot 2021-07-12 at 4 57 49 PM](https://user-images.githubusercontent.com/49017057/125280183-678b8980-e332-11eb-9135-4f6a59e4c015.png)
