### PR TITLE
chore: [PIP-9]: Corrected the disabled css for form input fields

### DIFF
--- a/src/components/FormikForm/FormikForm.css
+++ b/src/components/FormikForm/FormikForm.css
@@ -45,6 +45,13 @@
         &:focus {
           border-color: var(--primary-7);
         }
+
+        &:disabled {
+          background-color: var(--grey-50);
+          color: var(--grey-400);
+          border-color: var(--grey-200);
+          box-shadow: none;
+        }
       }
     }
 


### PR DESCRIPTION
Corrected the disabled look for form input fields. Specifically, used the lighter background color and font-weight.

Before -
![Screenshot 2021-07-23 at 5 15 11 PM](https://user-images.githubusercontent.com/49017057/126777366-38fd013b-902b-42f1-9ef0-2f5fc92a89f3.png)

After - 
![Screenshot 2021-07-23 at 5 14 52 PM](https://user-images.githubusercontent.com/49017057/126777382-0739bb7f-a767-433f-8448-0850673d3833.png)
