### PR TITLE
fix: [CDNG-11383]: Fixed the overflow issue for menu item in select & multiselect

### DIFF
--- a/src/components/FormikForm/FormikForm.stories.tsx
+++ b/src/components/FormikForm/FormikForm.stories.tsx
@@ -110,7 +110,12 @@ export const Basic: Story<FormikFormProps> = () => (
               placeholder="Select Color"
               items={[
                 { label: 'Red', value: 'red' },
-                { label: 'Blue', value: 'blue' }
+                { label: 'Blue', value: 'blue' },
+                {
+                  label: 'TryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTrying',
+                  value: 'xyz'
+                },
+                { label: 'Trying a long phrase with spaces to try out different combinations', value: 'abcd' }
               ]}
             />
             <FormInput.MultiSelect
@@ -120,20 +125,11 @@ export const Basic: Story<FormikFormProps> = () => (
               items={[
                 { label: 'Red', value: 'red' },
                 { label: 'Blue', value: 'blue' },
-                { label: 'Blue2', value: 'blue2' },
-                { label: 'Blue3', value: 'blue3' },
-                { label: 'Blue4', value: 'blue4' },
-                { label: 'Blue44', value: 'blue44' },
-                { label: 'Blue54', value: 'blue45w' },
                 {
-                  label:
-                    'Blueqw Blueqw Blueqw Blueqw BlueqwBlueqw Blueqw BlueqwBlueqw Blueqw BlueqwBlueqw Blueqw BlueqwBlueqw Blueqw Blueqw',
-                  value: 'blueqw'
+                  label: 'TryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTrying',
+                  value: 'xyz'
                 },
-                { label: 'Bluewew', value: 'bluewew' },
-                { label: 'Bluedd', value: 'blues' },
-                { label: 'Bluegf', value: 'bluesde' },
-                { label: 'Bluefgf', value: 'blueww' }
+                { label: 'Trying a long phrase with spaces to try out different combinations', value: 'abcd' }
               ]}
             />
             <FormInput.TextArea name="description" label="Description" />
@@ -142,7 +138,12 @@ export const Basic: Story<FormikFormProps> = () => (
               label="Job"
               selectItems={[
                 { label: 'Software Engineer', value: 'SE' },
-                { label: 'Quality Engineer', value: 'QE' }
+                { label: 'Quality Engineer', value: 'QE' },
+                {
+                  label: 'TryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTrying',
+                  value: 'xyz'
+                },
+                { label: 'Trying a long phrase with spaces to try out different combinations', value: 'abcd' }
               ]}
               useValue
               multiTypeInputProps={{
@@ -150,7 +151,12 @@ export const Basic: Story<FormikFormProps> = () => (
                   addClearBtn: true,
                   items: [
                     { label: 'Software Engineer', value: 'SE' },
-                    { label: 'Quality Engineer', value: 'QE' }
+                    { label: 'Quality Engineer', value: 'QE' },
+                    {
+                      label: 'TryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTrying',
+                      value: 'xyz'
+                    },
+                    { label: 'Trying a long phrase with spaces to try out different combinations', value: 'abcd' }
                   ]
                 }
               }}
@@ -162,7 +168,12 @@ export const Basic: Story<FormikFormProps> = () => (
               label="Hobbies"
               selectItems={[
                 { label: 'Basket Ball', value: 'BBall' },
-                { label: 'Drawing', value: 'Drawing' }
+                { label: 'Drawing', value: 'Drawing' },
+                {
+                  label: 'TryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTryingTrying',
+                  value: 'xyz'
+                },
+                { label: 'Trying a long phrase with spaces to try out different combinations', value: 'abcd' }
               ]}
             />
             <FormInput.CategorizedSelect

--- a/src/components/MultiSelect/MultiSelect.css
+++ b/src/components/MultiSelect/MultiSelect.css
@@ -102,6 +102,14 @@
     align-items: center;
     cursor: pointer;
 
+    .menuItemLabel {
+      color: var(--black);
+      font-weight: 400;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      word-break: break-all;
+    }
+
     & .checkbox {
       margin: 0 var(--spacing-small) 0 0;
     }

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -5,6 +5,7 @@ import { MultiSelect as BPMultiSelect, IMultiSelectProps, IItemRendererProps } f
 
 import css from './MultiSelect.css'
 import { Button } from '../../components/Button/Button'
+import { Text } from '../../components/Text/Text'
 import { Icon } from '../../icons/Icon'
 import { Utils } from '../../core/Utils'
 
@@ -136,7 +137,9 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
           disabled={item.disabled}
           readOnly
         />
-        {item.label}
+        <Text className={css.menuItemLabel} lineClamp={1}>
+          {item.label}
+        </Text>
       </li>
     )
   }

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -190,7 +190,12 @@ exports[`<MultiSelect/> tests works with filtering: Filtered Menu 1`] = `
                     type="checkbox"
                     value="004"
                   />
-                  Charmander
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmander
+                  </p>
                 </li>
                 <li
                   class="menuItem"
@@ -201,7 +206,12 @@ exports[`<MultiSelect/> tests works with filtering: Filtered Menu 1`] = `
                     type="checkbox"
                     value="005"
                   />
-                  Charmeleon
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmeleon
+                  </p>
                 </li>
                 <li
                   class="menuItem"
@@ -212,7 +222,12 @@ exports[`<MultiSelect/> tests works with filtering: Filtered Menu 1`] = `
                     type="checkbox"
                     value="006"
                   />
-                  Charizard
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charizard
+                  </p>
                 </li>
                 <button
                   class="bp3-button bp3-minimal button font main intent intent-primary with-current-color without-shadow"

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -10,6 +10,9 @@
     height: var(--spacing-8);
     color: var(--grey-900);
     box-shadow: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-all;
 
     &:hover {
       border-color: var(--primary-6);
@@ -81,8 +84,14 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-    color: var(--black);
-    font-weight: 400;
+
+    .menuItemLabel {
+      color: var(--black);
+      font-weight: 400;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      word-break: break-all;
+    }
 
     :global(.bp3-icon) {
       margin-right: var(--spacing-small);

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -53,17 +53,28 @@ export const Basic: Story<SelectProps> = args => {
 Basic.args = { size: SelectSize.Large }
 export const SelectWithIcons: Story<SelectProps> = args => {
   const {
-    size = SelectSize.Large,
     items = [
-      { label: 'Kubernetes', value: 'service-kubernetes', icon: { name: 'service-kubernetes' } },
-      { label: 'GitHub', value: 'service-github', icon: { name: 'service-github' } },
+      {
+        label: 'TryingTryingTryingTryingTryingTryingTryingTryingTrying',
+        value: 'service-kubernetes',
+        icon: { name: 'service-kubernetes' }
+      },
+      {
+        label: 'Trying a long phrase with spaces to try out different combinations',
+        value: 'service-github',
+        icon: { name: 'service-github' }
+      },
       { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' } },
       { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' } },
       { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' } }
     ]
   } = args
   const argsCopy = omit(args, ['size', 'items'])
-  return <Select size={size} items={items} addClearBtn={true} {...argsCopy} />
+  return (
+    <div style={{ width: '300px' }}>
+      <Select items={items} addClearBtn={true} {...argsCopy} />
+    </div>
+  )
 }
 SelectWithIcons.args = { size: SelectSize.Large }
 export const AsyncSelect: Story<SelectProps> = args => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,6 +7,7 @@ import css from './Select.css'
 import { Button } from '../../components/Button/Button'
 import { Icon, IconProps } from '../../icons/Icon'
 import { Utils } from '../../core/Utils'
+import { Text } from '../../components/Text/Text'
 
 export interface SelectOption {
   label: string
@@ -93,7 +94,9 @@ export function defaultItemRenderer(
       )}
       onClick={props.handleClick}>
       {item.icon ? <Icon size={getIconSizeFromSelect(size)} {...item.icon} /> : null}
-      {item.label}
+      <Text className={css.menuItemLabel} lineClamp={1}>
+        {item.label}
+      </Text>
     </li>
   )
 }

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -63,17 +63,32 @@ exports[`<Select/> tests basic filter works: Filtered Menu 1`] = `
                 <li
                   class="menuItem active"
                 >
-                  Charmander
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmander
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Charmeleon
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmeleon
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Charizard
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charizard
+                  </p>
                 </li>
               </ul>
             </div>
@@ -148,102 +163,202 @@ exports[`<Select/> tests basic filter works: Initial Menu 1`] = `
                 <li
                   class="menuItem active"
                 >
-                  Bulbasaur
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Bulbasaur
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Ivysaur
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Ivysaur
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Venusaur
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Venusaur
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Charmander
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmander
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Charmeleon
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmeleon
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Charizard
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charizard
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Squirtle
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Squirtle
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Wartortle
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Wartortle
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Blastoise
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Blastoise
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Caterpie
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Caterpie
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Metapod
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Metapod
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Butterfree
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Butterfree
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Weedle
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Weedle
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Kakuna
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Kakuna
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Beedrill
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Beedrill
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Pidgey
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Pidgey
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Pidgeotto
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Pidgeotto
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Pidgeot
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Pidgeot
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Rattata
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Rattata
+                  </p>
                 </li>
                 <li
                   class="menuItem"
                 >
-                  Raticate
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Raticate
+                  </p>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
1. Added the Text component with line clamp for the menu options
2. Used ellipsis to denote long texts (for a lengthy word and a lengthy sentence)
3. used ellipsis to denote long text in the selected value

Before - 
![image-20210730-104610](https://user-images.githubusercontent.com/49017057/127998810-33e2d6f3-f65e-476b-8349-3851393c9184.png)
![image-2021-07-30-16-14-37-716](https://user-images.githubusercontent.com/49017057/127998840-545a281d-5e75-48d0-b257-ecbf7d3ac1a6.png)


After - 
![Screenshot 2021-08-03 at 2 20 39 PM](https://user-images.githubusercontent.com/49017057/127998916-b9e0073b-da9c-4dda-95e8-9373d802b9f8.png)
![Screenshot 2021-08-03 at 2 22 50 PM](https://user-images.githubusercontent.com/49017057/127998917-53081a60-0084-4727-9453-723160bcb1ff.png)
![Screenshot 2021-08-03 at 2 25 38 PM](https://user-images.githubusercontent.com/49017057/127998919-e6f7c517-596c-41e1-a0a2-f516d22687f7.png)
![Screenshot 2021-08-03 at 2 26 00 PM](https://user-images.githubusercontent.com/49017057/127998923-b42e0684-9824-401b-ae89-8e30a4750bcb.png)
