### PR TITLE
fix: [CDNG-116446]: Reset the original padding on existing component

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -1,6 +1,6 @@
 .dialog {
   border-radius: 5px;
-
+  border-left: 0px !important;
   box-shadow: none !important;
   background: var(--white) !important;
   padding: var(--dialog-padding);

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -1,6 +1,7 @@
 :global {
   .bp3-portal {
     .bp3-dialog {
+      border-left: 20px solid var(--blue-500);
       box-shadow: none;
       background: var(--white);
       .bp3-dialog-header {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
