### PR TITLE
feat: [PL-19785]: Adding chart icons for overview landing page

### DIFF
--- a/src/icons/HarnessIcons.ts
+++ b/src/icons/HarnessIcons.ts
@@ -30,6 +30,7 @@ import AwsSecretManager from './aws-secret-manager.svg'
 import AzureKeyVault from './azure-key-vault.svg'
 import AzureKubernetesService from './azure-kubernetes-service.svg'
 import Banned from './banned.svg'
+import BarChart from './bar-chart.svg'
 import BarrierClose from './barrier-close.svg'
 import BarrierOpenWithLinks from './barrier-open-with-links.svg'
 import BarrierOpen from './barrier-open.svg'
@@ -231,6 +232,7 @@ import LayoutBottom from './layout-bottom.svg'
 import LayoutFloat from './layout-float.svg'
 import LayoutRight from './layout-right.svg'
 import Library from './library.svg'
+import LineChart from './line-chart.svg'
 import Linkedin from './linkedin.svg'
 import ListEntityInfographic from './list-entity-infographic.svg'
 import ListView from './list-view.svg'
@@ -590,6 +592,7 @@ type HarnessIconName =
   | 'azure-key-vault'
   | 'azure-kubernetes-service'
   | 'banned'
+  | 'bar-chart'
   | 'barrier-close'
   | 'barrier-open-with-links'
   | 'barrier-open'
@@ -791,6 +794,7 @@ type HarnessIconName =
   | 'layout-float'
   | 'layout-right'
   | 'library'
+  | 'line-chart'
   | 'linkedin'
   | 'list-entity-infographic'
   | 'list-view'
@@ -1150,6 +1154,7 @@ const HarnessIcons: KVO<FunctionComponent<ElementType>> = {
   'azure-key-vault': AzureKeyVault,
   'azure-kubernetes-service': AzureKubernetesService,
   banned: Banned,
+  'bar-chart': BarChart,
   'barrier-close': BarrierClose,
   'barrier-open-with-links': BarrierOpenWithLinks,
   'barrier-open': BarrierOpen,
@@ -1351,6 +1356,7 @@ const HarnessIcons: KVO<FunctionComponent<ElementType>> = {
   'layout-float': LayoutFloat,
   'layout-right': LayoutRight,
   library: Library,
+  'line-chart': LineChart,
   linkedin: Linkedin,
   'list-entity-infographic': ListEntityInfographic,
   'list-view': ListView,

--- a/src/icons/bar-chart.svg
+++ b/src/icons/bar-chart.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 14 11" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.995 0v10.798H14V0h-2.005zM3.996 1.601v9.197h2.005V1.6H3.996zm4.003 1.601v7.596h1.998V3.202H7.999zM0 4.797v6h1.998v-6H0z" fill="currentColor"/></svg>

--- a/src/icons/line-chart.svg
+++ b/src/icons/line-chart.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 14 11" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.758 10.265L5.703 1.807l-2.799 4.1H0v-.746h2.51L6.032 0l2.076 8.546 2.81-3.765H14v.747h-2.706l-3.536 4.737z" fill="currentColor"/></svg>


### PR DESCRIPTION
Adding following chart icons for overview landing page

<img width="366" alt="Screenshot 2021-09-22 at 2 05 04 AM" src="https://user-images.githubusercontent.com/63278928/134243681-9d1df24f-1172-4300-91d0-c9799f88e364.png">

You can use the following comments to re-trigger PR Checks
- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
