### PR TITLE
feat: [CVNG-3675]: Added icons support

### DIFF
--- a/src/components/GridListToggle/GridListToggle.tsx
+++ b/src/components/GridListToggle/GridListToggle.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+import { IconName } from 'index'
 import { Button } from '../Button/Button'
 import { Layout } from '../../layouts/Layout'
 import css from './GridListToggle.css'
@@ -12,10 +13,14 @@ export enum Views {
 export interface GridListToggleProps {
   initialSelectedView?: Views
   onViewToggle?: (selectedView: Views) => void
+  icons?: {
+    left?: IconName
+    right?: IconName
+  }
 }
 
 export function GridListToggle(props: GridListToggleProps): JSX.Element {
-  const { initialSelectedView, onViewToggle } = props
+  const { initialSelectedView, onViewToggle, icons } = props
   const [selectedView, setSelectedView] = React.useState<Views>(initialSelectedView || Views.GRID)
 
   React.useEffect(() => {
@@ -32,7 +37,7 @@ export function GridListToggle(props: GridListToggleProps): JSX.Element {
           css.gridButton
         )}
         minimal
-        icon="grid-view"
+        icon={icons?.left ?? 'grid-view'}
         intent={selectedView === Views.GRID ? 'primary' : undefined}
         onClick={() => {
           setSelectedView(Views.GRID)
@@ -49,7 +54,7 @@ export function GridListToggle(props: GridListToggleProps): JSX.Element {
           css.listButton
         )}
         minimal
-        icon="list"
+        icon={icons?.right ?? 'list'}
         intent={selectedView === Views.LIST ? 'primary' : undefined}
         onClick={() => {
           setSelectedView(Views.LIST)


### PR DESCRIPTION
Added left and right custom icons support for `GridListToggle`.

<img width="96" alt="Screenshot 2021-10-18 at 10 35 46 AM" src="https://user-images.githubusercontent.com/80388547/137672292-f727fe8c-35da-483d-afb2-76e0b2713ba9.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
