### PR TITLE
fix: [PL-20569]: fix onclick when card is disabled

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -59,7 +59,7 @@ export const Card: React.FC<CardProps> = props => {
         { [css.interactive]: bpProps.interactive }
       )}
       style={style}
-      onClick={onClick}>
+      onClick={disabled ? undefined : onClick}>
       {selected && cornerSelected && renderCornerTick()}
       {props.children}
     </BpCard>


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
