### PR TITLE
feat: primary intent type added in toaster

### DIFF
--- a/src/hooks/useToaster/useToaster.tsx
+++ b/src/hooks/useToaster/useToaster.tsx
@@ -11,6 +11,7 @@ export interface ToasterProps extends IToaster {
   showSuccess: (message: string | ReactNode, timeout?: number, key?: string) => void
   showError: (message: string | ReactNode, timeout?: number, key?: string) => void
   showWarning: (message: string | ReactNode, timeout?: number, key?: string) => void
+  showPrimary: (message: string | ReactNode, timeout?: number, key?: string) => void
 }
 
 const showSuccess = (message: string | ReactNode, timeout?: number, key?: string): void => {
@@ -25,12 +26,17 @@ const showWarning = (message: string | ReactNode, timeout?: number, key?: string
   toaster.show({ message, intent: Intent.WARNING, icon: 'warning-sign', timeout }, key)
 }
 
+const showPrimary = (message: string | ReactNode, timeout?: number, key?: string): void => {
+  toaster.show({ message, intent: Intent.PRIMARY, timeout }, key)
+}
+
 export function useToaster(): ToasterProps {
   return {
     ...toaster,
     showSuccess,
     showError,
     showWarning,
+    showPrimary,
     clear: () => {
       toaster.clear()
     }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
