### PR TITLE
chore: remove 'utility-types' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "ts-loader": "^9.2.3",
     "tslib": "^2.0.3",
     "typescript": "^4.1.3",
-    "utility-types": "^3.9.0",
     "webpack": "^5.41.0",
     "webpack-cli": "^4.7.2",
     "webpack-node-externals": "^3.0.0",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,6 @@ import { AnchorButton, Button as BButton, IButtonProps } from '@blueprintjs/core
 import cx from 'classnames'
 import { HarnessDocTooltip } from '../../frameworks/Tooltip/Tooltip'
 import React, { ElementType, HTMLAttributes, MouseEvent, useState } from 'react'
-import { Assign } from 'utility-types'
 import { Config } from '../../core/Config'
 import { OptionalTooltip } from '../../core/Types'
 import { Utils } from '../../core/Utils'
@@ -28,10 +27,9 @@ export enum ButtonSize {
 }
 
 export interface ButtonProps
-  extends Assign<
-      Omit<IButtonProps, 'icon' | 'rightIcon' | 'onClick'>,
-      Assign<HTMLAttributes<HTMLButtonElement>, StyledProps>
-    >,
+  extends Omit<IButtonProps, 'icon' | 'rightIcon' | 'onClick'>,
+    HTMLAttributes<HTMLButtonElement>,
+    StyledProps,
     OptionalTooltip {
   /** Left icon */
   icon?: IconName

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,3 @@
-import { Assign } from 'utility-types'
 import { Checkbox as BpCheckbox, ICheckboxProps } from '@blueprintjs/core'
 import { StyledProps, omitStyledProps, styledClasses } from '../../styled-props/StyledProps'
 import React, { FormEvent, ReactElement } from 'react'
@@ -6,7 +5,7 @@ import styledClass from '../../styled-props/StyledProps.css'
 
 import css from './Checkbox.css'
 
-export interface CheckboxProps extends Assign<Omit<ICheckboxProps, 'onChange'>, StyledProps> {
+export interface CheckboxProps extends Omit<ICheckboxProps, 'onChange'>, StyledProps {
   /** onChange event handler */
   onChange?: (event: FormEvent<HTMLInputElement>) => void
 

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,9 +1,8 @@
 import React, { HTMLAttributes } from 'react'
 import { StyledProps, styledClasses, omitStyledProps } from '../../styled-props/StyledProps'
-import { Assign } from 'utility-types'
 import styledClass from '../../styled-props/StyledProps.css'
 
-export interface ContainerProps extends Assign<HTMLAttributes<HTMLDivElement>, StyledProps> {
+export interface ContainerProps extends HTMLAttributes<HTMLDivElement>, StyledProps {
   tag?: keyof JSX.IntrinsicElements
 }
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,11 +1,10 @@
 import React, { HTMLAttributes } from 'react'
-import { Assign } from 'utility-types'
 import { StyledProps, styledClasses, omitStyledProps } from '../../styled-props/StyledProps'
 import styledClass from '../../styled-props/StyledProps.css'
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6'
 
-export interface HeadingProps extends Assign<HTMLAttributes<HTMLHeadingElement>, StyledProps> {
+export interface HeadingProps extends HTMLAttributes<HTMLHeadingElement>, StyledProps {
   /** Heading level ('1' -> h1, '2' -> h2, ..., '6' -> h6). Default is '1' */
   level?: HeadingLevel
 }
@@ -13,7 +12,7 @@ export interface HeadingProps extends Assign<HTMLAttributes<HTMLHeadingElement>,
 /**
  * Heading renders consistent H1 to H6 elements.
  */
-export function Heading(props: HeadingProps) {
+export function Heading(props: HeadingProps): React.ReactElement {
   const { level = 1, children } = props
   const Tag = `h${level}` as React.ElementType
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,4 +1,3 @@
-import { Assign } from 'utility-types'
 import { Radio as BpRadio, RadioGroup as BpRadioGroup, IRadioProps } from '@blueprintjs/core'
 import { StyledProps, omitStyledProps, styledClasses } from '../../styled-props/StyledProps'
 import React, { FormEvent } from 'react'
@@ -6,7 +5,7 @@ import styledClass from '../../styled-props/StyledProps.css'
 
 import css from './Radio.css'
 
-export interface RadioGroupProps extends Assign<Omit<IRadioProps, 'onChange'>, StyledProps> {
+export interface RadioGroupProps extends Omit<IRadioProps, 'onChange'>, StyledProps {
   /** onChange event handler */
   onChange?: (event: FormEvent<HTMLInputElement>) => void
 
@@ -17,7 +16,7 @@ export interface RadioGroupProps extends Assign<Omit<IRadioProps, 'onChange'>, S
   children?: React.ReactNode
 }
 
-export interface RadioProps extends Assign<Omit<IRadioProps, 'onChange'>, StyledProps> {
+export interface RadioProps extends Omit<IRadioProps, 'onChange'>, StyledProps {
   /** onChange event handler */
   onChange?: (event: FormEvent<HTMLInputElement>) => void
 
@@ -25,7 +24,7 @@ export interface RadioProps extends Assign<Omit<IRadioProps, 'onChange'>, Styled
   className?: string
 }
 
-function RadioGroup(props: RadioGroupProps) {
+function RadioGroup(props: RadioGroupProps): React.ReactElement {
   const { children, className = '', onChange = () => void 0 } = props
   return (
     <BpRadioGroup
@@ -37,7 +36,7 @@ function RadioGroup(props: RadioGroupProps) {
   )
 }
 
-function Radio(props: RadioProps) {
+function Radio(props: RadioProps): React.ReactElement {
   const { className = '', onChange = () => void 0 } = props
 
   return (

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,5 +1,4 @@
 import React, { FormEvent } from 'react'
-import { Assign } from 'utility-types'
 import { Switch as BpSwitch, ISwitchProps } from '@blueprintjs/core'
 import { omit } from 'lodash-es'
 import { StyledProps, omitStyledProps, styledClasses } from '../../styled-props/StyledProps'
@@ -9,7 +8,7 @@ import css from './Switch.css'
 import { HarnessDocTooltip } from '../../frameworks/Tooltip/Tooltip'
 import type { TooltipRenderProps } from '../../frameworks/Tooltip/types'
 
-export interface SwitchProps extends Assign<Omit<ISwitchProps, 'onChange'>, StyledProps> {
+export interface SwitchProps extends Omit<ISwitchProps, 'onChange'>, StyledProps {
   /** onChange event handler */
   onChange?: (event: FormEvent<HTMLInputElement>) => void
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,5 +1,4 @@
 import React, { HTMLAttributes, useRef, useLayoutEffect, useState, useEffect } from 'react'
-import { Assign } from 'utility-types'
 import cx from 'classnames'
 import { StyledProps, styledClasses, omitStyledProps } from '../../styled-props/StyledProps'
 import styledCSS from '../../styled-props/StyledProps.css'
@@ -9,7 +8,7 @@ import css from './Text.css'
 import { Icon, IconName, IconProps } from '../../icons/Icon'
 import { HarnessDocTooltip } from '../../frameworks/Tooltip/Tooltip'
 
-export interface TextProps extends Assign<HTMLAttributes<HTMLDivElement>, StyledProps>, OptionalTooltip {
+export interface TextProps extends HTMLAttributes<HTMLDivElement>, StyledProps, OptionalTooltip {
   // When lineClamp is specified, show ... (ellipsis) when text is overflown and show the full text
   // in a tooltip on hover. Note that `tooltip` prop takes precedence over this prop.
   // See more: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp

--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -6,19 +6,18 @@
  */
 import { HarnessIcons, HarnessIconName } from './HarnessIcons'
 import React, { ElementType, HTMLAttributes } from 'react'
-import { Assign } from 'utility-types'
 import { Icon as BIcon, IconName as BIconName, Classes } from '@blueprintjs/core'
 import { StyledProps, styledClasses, omitStyledProps } from '../styled-props/StyledProps'
 
 type IconName = HarnessIconName | BIconName
 
-interface IconProps extends Assign<HTMLAttributes<HTMLHeadingElement>, Omit<StyledProps, 'children'>> {
+interface IconProps extends HTMLAttributes<HTMLHeadingElement>, Omit<StyledProps, 'children'> {
   name: IconName
   inverse?: boolean
   size?: number
 }
 
-function Icon(props: IconProps) {
+function Icon(props: IconProps): React.ReactElement {
   const name = props.name as string
   const size = props.size || 16
   let HarnessIcon: ElementType = HarnessIcons[name]

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,11 +1,10 @@
 import React, { HTMLAttributes } from 'react'
-import { Assign } from 'utility-types'
 import { StyledProps, styledClasses, omitStyledProps } from '../styled-props/StyledProps'
 import css from './Layout.css'
 import { Spacing } from 'core/Spacing'
 import { Masonry, MasonryRef, MasonryProps } from './Masonry'
 
-export interface LayoutProps extends Assign<HTMLAttributes<HTMLDivElement>, StyledProps> {
+export interface LayoutProps extends HTMLAttributes<HTMLDivElement>, StyledProps {
   /** Spacing among children */
   spacing?: Spacing
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14330,11 +14330,6 @@ utila@~0.4:
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
-utility-types@^3.9.0:
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
-  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
-
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
