### PR TITLE
fix: Added prop to handle maxlength from consumer

### DIFF
--- a/src/components/FormikForm/FormikForm.tsx
+++ b/src/components/FormikForm/FormikForm.tsx
@@ -778,6 +778,7 @@ export interface TextAreaProps extends Omit<IFormGroupProps, 'labelFor'> {
   autoFocus?: boolean
   textArea?: Omit<ITextAreaProps, 'name' | 'value' | 'onChange'>
   onChange?: ITextAreaProps['onChange']
+  maxLength?: number
 }
 
 const TextArea = (props: TextAreaProps & FormikContextProps<any>) => {
@@ -792,6 +793,7 @@ const TextArea = (props: TextAreaProps & FormikContextProps<any>) => {
     label,
     textArea,
     onChange,
+    maxLength = 1024,
     ...rest
   } = restProps
 
@@ -809,7 +811,7 @@ const TextArea = (props: TextAreaProps & FormikContextProps<any>) => {
         fill={true}
         autoFocus={autoFocus}
         autoComplete={autoComplete}
-        maxLength={1024}
+        maxLength={maxLength}
         {...textArea}
         name={name}
         intent={intent}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
