### PR TITLE
fix: [CI-2868]: Adding fallback user icon when img url fails to load 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wings-software/uicore",
-  "version": "0.1.442",
+  "version": "0.1.441",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

![image](https://user-images.githubusercontent.com/48940704/141133398-b23baa58-fb4a-4ea2-bf29-e5e9bfb2f937.png)

Adding fallback icon "user" when image src fails to load.

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
