### PR TITLE
fix: [PIE-1761]: Propagated the value as number if `MultiTextInput` is type number

### DIFF
--- a/src/components/FormikForm/FormikForm.stories.tsx
+++ b/src/components/FormikForm/FormikForm.stories.tsx
@@ -820,6 +820,12 @@ export const Basic: Story<FormikFormProps> = () => (
             />
             <FormInput.MultiTextInput name="jobDesc1" label="Job Desc 1" />
             <FormInput.MultiTextInput name="jobDec2" placeholder="Job Desc" label="Job Desc 2" />
+            <FormInput.MultiTextInput
+              name="numbertype"
+              multiTextInputProps={{ textProps: { type: 'number' } }}
+              placeholder="Number type multi text"
+              label="Number type multi text"
+            />
             <FormInput.MultiSelectTypeInput
               name="hobbies"
               label="Hobbies"

--- a/src/components/FormikForm/FormikForm.tsx
+++ b/src/components/FormikForm/FormikForm.tsx
@@ -1174,8 +1174,14 @@ const FormMultiTextTypeInput = (props: FormMultiTextTypeInputProps & FormikConte
         textProps={{ ...customTextInputProps, autoComplete }}
         name={name}
         onChange={(valueChange, valueType, type) => {
-          formik?.setFieldValue(name, valueChange)
-          onChange?.(value, valueType, type)
+          let valueToBePassed = valueChange
+          const inputFieldType = multiTextInputProps?.textProps?.type
+          if (inputFieldType === 'number' && valueChange && typeof valueChange === 'string') {
+            // if the type is a number, propagate the value as a number
+            valueToBePassed = parseFloat(valueChange)
+          }
+          formik?.setFieldValue(name, valueToBePassed)
+          onChange?.(valueToBePassed, valueType, type)
         }}
       />
     </FormGroup>

--- a/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -22,7 +22,7 @@ import {
 } from './MultiTypeInputUtils'
 import { MultiTypeInputMenu } from './MultiTypeInputMenu'
 
-type AcceptableValue = boolean | string | SelectOption | MultiSelectOption[]
+type AcceptableValue = boolean | string | number | SelectOption | MultiSelectOption[]
 
 export interface ExpressionAndRuntimeTypeProps<T = unknown> extends Omit<LayoutProps, 'onChange'> {
   value?: AcceptableValue


### PR DESCRIPTION
| Before | After |
| ------  | ----- |
|<img width="1012" alt="Screenshot 2021-11-13 at 11 37 58 AM" src="https://user-images.githubusercontent.com/49017057/141608050-710c4968-4816-4f94-a164-2965f7ed325a.png">|<img width="994" alt="Screenshot 2021-11-13 at 11 37 39 AM" src="https://user-images.githubusercontent.com/49017057/141608061-bb128cac-268c-4017-a11e-60a84eceb6fe.png">|

