### PR TITLE
chore: Added optional tooltip support in Thumbail select item

### DIFF
--- a/src/components/ThumbnailSelect/ThumbnailSelect.tsx
+++ b/src/components/ThumbnailSelect/ThumbnailSelect.tsx
@@ -96,7 +96,7 @@ const ThumbnailSelect: React.FC<ConnectedThumbnailSelectProps> = props => {
       <Layout.Horizontal spacing={'medium'} {...layoutProps}>
         {visibleItems.map(item => {
           return (
-            <WrapOptionalTooltip tooltip={item.tooltip} tooltipProps={item.tooltipProps}>
+            <WrapOptionalTooltip key={item.value} tooltip={item.tooltip} tooltipProps={item.tooltipProps}>
               <Thumbnail
                 size={size}
                 name={name}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
