### PR TITLE
feat: add support for custom class names to dialog

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import { Container, Icon } from '../..'
 import { Dialog as BluePrintDialog, IDialogProps } from '@blueprintjs/core'
 import css from './Dialog.css'
@@ -6,6 +7,7 @@ import css from './Dialog.css'
 export interface DialogProps extends IDialogProps {
   footer?: JSX.Element | JSX.Element[]
   children?: JSX.Element | JSX.Element[]
+  chidrenClassName?: string
 }
 
 const defaultProps = {
@@ -16,11 +18,15 @@ const defaultProps = {
   canEscapeKeyClose: true
 }
 
-export function Dialog(props: DialogProps) {
+export function Dialog(props: DialogProps): React.ReactElement {
   return (
-    <BluePrintDialog {...defaultProps} {...props} className={css.dialog} isCloseButtonShown={false}>
+    <BluePrintDialog
+      {...defaultProps}
+      {...props}
+      className={cx(css.dialog, props.className)}
+      isCloseButtonShown={false}>
       <Icon name="Stroke" size={15} onClick={props.onClose} className={css.close} />
-      <Container padding="none" className={css.children}>
+      <Container padding="none" className={cx(css.children, props.chidrenClassName)}>
         {props.children}
       </Container>
       <footer>{props.footer}</footer>


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
