### PR TITLE
fix: [PIE-1832]: add useEffect for initialSelectedView prop changes

### DIFF
--- a/src/components/PillToggle/PillToggle.tsx
+++ b/src/components/PillToggle/PillToggle.tsx
@@ -19,6 +19,12 @@ export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement =>
   const { initialSelectedView, beforeOnChange, disableSwitch = false, className = '', options } = props
   const [selectedView, setSelectedView] = React.useState<T>(initialSelectedView || options[0].value)
 
+  React.useEffect(() => {
+    if (selectedView !== initialSelectedView) {
+      setSelectedView(initialSelectedView || options[0].value)
+    }
+  }, [initialSelectedView])
+
   return (
     <div className={cx(css.optionBtns, className)}>
       <div


### PR DESCRIPTION
Summary: Changing initialSelectedView after initial rendering is not working

JIRA - https://harness.atlassian.net/browse/PIE-1832


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
