### PR TITLE
fix: [GTM-635]: fix Page Header default background to be white

### DIFF
--- a/src/components/Page/PageHeader.css
+++ b/src/components/Page/PageHeader.css
@@ -2,7 +2,6 @@
   padding-top: var(--spacing-4) !important;
   padding-bottom: 10px !important;
   border-bottom: 1px solid var(--grey-200);
-  background: var(--white);
   position: relative;
   z-index: 2;
 

--- a/src/components/Page/PageHeader.tsx
+++ b/src/components/Page/PageHeader.tsx
@@ -31,7 +31,8 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
       flex
       className={cx(css.container, css[size], className)}
       padding={{ left: 'xlarge', right: 'xlarge' }}
-      data-testid={testId}>
+      data-testid={testId}
+      background={Color.WHITE}>
       <Layout.Vertical>
         {breadcrumbs && <div className={css.breadcrumbsDiv}>{breadcrumbs}</div>}
         {typeof title === 'string' ? (


### PR DESCRIPTION
this is to fix Page Header component background color to be default white

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
