### PR TITLE
fix: [PIE-2023]: safe check added in getIdentifierFromName util

### DIFF
--- a/src/components/InputWithIdentifier/InputWithIdentifier.tsx
+++ b/src/components/InputWithIdentifier/InputWithIdentifier.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react'
 import { EditableText, Popover, PopoverInteractionKind } from '@blueprintjs/core'
-import { get } from 'lodash-es'
+import { get, isNil } from 'lodash-es'
 import cx from 'classnames'
 import { FormikTooltipContext } from '../FormikForm/FormikTooltipContext'
 
@@ -45,7 +45,7 @@ export interface InputWithIdentifierProps {
 
 // https://harness.atlassian.net/wiki/spaces/CDNG/pages/736200458/Entity+Identifier
 export function getIdentifierFromName(str: string): string {
-  if (!str) return ''
+  if (isNil(str)) return ''
 
   return str
     .trim()


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
