### PR TITLE
fix: [PIE-1661]: height fixed for multi type input icon

### DIFF
--- a/src/components/MultiTypeInput/MultiTypeInput.css
+++ b/src/components/MultiTypeInput/MultiTypeInput.css
@@ -192,7 +192,7 @@
 
   &::before {
     content: '';
-    height: 28px;
+    height: 30px;
     left: var(--spacing-4);
     width: var(--spacing-3);
     transform: translateX(-18px);


### PR DESCRIPTION


**Before fix : 1px space can be seen on top and bottom around the separation between icon and input area**

<img width="923" alt="Screenshot 2022-01-05 at 1 25 11 PM" src="https://user-images.githubusercontent.com/96409598/148290991-dd36d47b-0b21-499b-b007-4e4f02f7f5ff.png">


**After fix ---->** 


<img width="1002" alt="Screenshot 2022-01-05 at 1 24 18 PM" src="https://user-images.githubusercontent.com/96409598/148290978-87fb5c82-2f2f-4324-b7da-f4dcf024fd2d.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
