### PR TITLE
fix: [PL-21212]: fixed alignment of error icon

### DIFF
--- a/src/components/FormError/FormError.css
+++ b/src/components/FormError/FormError.css
@@ -1,7 +1,22 @@
+.errorDiv {
+  margin-top: var(--spacing-small);
+  display: flex;
+}
+
 .error {
+  font-size: var(--font-size-normal);
+  color: var(--red-600);
+  margin-left: var(--spacing-xsmall);
   word-break: break-word;
 }
 
+.errorIcon {
+  :global(.bp3-icon:first-child) {
+    color: var(--red-600);
+  }
+}
+
 .errorTextIcon {
+  color: var(--red-600);
   margin-top: var(--spacing-tiny) !important;
 }

--- a/src/components/FormError/FormError.tsx
+++ b/src/components/FormError/FormError.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 import { FormikErrors } from 'formik'
-import { Layout, Text, Color, Icon } from '../../'
+import { Icon } from '../../icons/Icon'
 import css from './FormError.css'
 
 export const FormError = ({ errorMessage }: { errorMessage: string | undefined | FormikErrors<any> }) => {
   if (!errorMessage) {
     return null
   }
-
   // Used to display form errors below the fields, with an icon
   return (
-    <Layout.Horizontal margin={{ top: 'small' }}>
-      <Icon className={css.errorTextIcon} name="circle-cross" margin={{ right: 'xsmall' }} size={12} intent="danger" />
-      <Text className={css.error} color={Color.RED_600}>
-        {errorMessage}
-      </Text>
-    </Layout.Horizontal>
+    <div className={css.errorDiv}>
+      <Icon name="circle-cross" className={css.errorTextIcon} size={12} intent="danger" />
+      <span className={css.error}>{errorMessage}</span>
+    </div>
   )
 }


### PR DESCRIPTION
**Summary:**
Error-Icon Alignment and word-break fix

**Jira Links:**
[https://harness.atlassian.net/browse/PL-21212](https://harness.atlassian.net/browse/PL-21212)

**Before fix 1 : Error-Icon Alignment**
![image](https://user-images.githubusercontent.com/96057095/148988959-a98f6f5c-6443-4c0f-a0a2-c821638580b0.png)

**After fix 1: Error-Icon Alignment**
![image](https://user-images.githubusercontent.com/96057095/148989333-28bc3602-2fd6-4d1e-aa6d-52ea6905e362.png)

**Before fix 2 : Word-break**
![image](https://user-images.githubusercontent.com/96057095/148989970-46d85f9d-7ade-447a-8120-38795dc8770e.png)

**After fix 2 : Word-break**
![image](https://user-images.githubusercontent.com/96057095/148990072-6f343c2a-1e6c-4168-b5f8-21d060c45a7b.png)


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
