### PR TITLE
fix: [ONP-257]: run stamp script in bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "lint-staged": {
     "*": [
-      "sh scripts/license/stamp.sh"
+      "scripts/license/stamp.sh"
     ],
     "src/**/*.{js,jsx}": [
       "sh -c 'exit 1'"


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
