### PR TITLE
fix: [PIE-1755]: MultiTypeInput - Prevent the click event when enter key pressed in InputGroup

### DIFF
--- a/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useState, useCallback, useMemo, useEffect, SyntheticEvent } from 'react'
+import React, { useState, useCallback, useMemo, useEffect } from 'react'
 import { Button } from '../Button/Button'
 import { Select, SelectProps, SelectOption } from '../Select/Select'
 import { TextInput } from '../TextInput/TextInput'

--- a/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import React, { useState, useCallback, useMemo, useEffect, SyntheticEvent } from 'react'
 import { Button } from '../Button/Button'
 import { Select, SelectProps, SelectOption } from '../Select/Select'
 import { TextInput } from '../TextInput/TextInput'
@@ -167,7 +167,18 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
             <MultiTypeInputMenu i18n={i18n} onTypeSelect={switchType} allowedTypes={allowableTypes} />
           )
         }
-        onClick={e => e.preventDefault()}
+        onClick={ev => {
+          if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
+            /*
+            PIE-1755
+            https://github.com/palantir/blueprint/issues/3856
+            Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
+            So checking the event pointer type, and stopping the propagation if not clicked by the user
+            */
+            ev.stopPropagation()
+          }
+          ev.preventDefault()
+        }}
         disabled={disabled}
         tooltipProps={{
           minimal: true,


### PR DESCRIPTION


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
