### PR TITLE
fix: [PL-15054]: border-radius fix for PageSpinner

### DIFF
--- a/src/components/Page/PageSpinner.css
+++ b/src/components/Page/PageSpinner.css
@@ -7,9 +7,9 @@
 
 .spinner {
   position: absolute;
-  width: 100%;
-  height: 100%;
   top: 0;
+  right: 0;
+  bottom: 0;
   left: 0;
   z-index: 20;
   backdrop-filter: blur(5px);

--- a/src/components/Page/PageSpinner.css
+++ b/src/components/Page/PageSpinner.css
@@ -14,6 +14,7 @@
   z-index: 20;
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
+  border-radius: inherit;
 
   @supports not ((backdrop-filter: blur(5px)) or (-webkit-backdrop-filter: blur(5px))) {
     background-color: rgba(255, 255, 255, 0.8) !important;


### PR DESCRIPTION
**Summary:**
Border-radius fix for PageSpinner 

**JIRA:**
https://harness.atlassian.net/browse/PL-15054

**Screenshots:**

Before (no border-radius with Spinner on top of parent-component):
![image](https://user-images.githubusercontent.com/96057095/150794884-e9790686-3ea1-4d7e-895a-e161f8283dad.png)

After (added border-radius with Spinner on top of parent-component):
![image](https://user-images.githubusercontent.com/96057095/150795115-f4716276-259a-436c-a9ee-5e9cf3fae3cd.png)


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
