### PR TITLE
feat: remove error throw from useModal

### DIFF
--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -23,18 +23,9 @@ export interface ModalContextType {
 }
 
 /**
- * Throw error when ModalContext is used outside of context provider
- */
-const invariantViolation = () => {
-  throw new Error(
-    'Attempted to call useModal outside of modal context. Make sure your app is rendered inside ModalProvider.'
-  )
-}
-
-/**
  * Modal Context Object
  */
 export const ModalContext = React.createContext<ModalContextType>({
-  showModal: invariantViolation,
-  hideModal: invariantViolation
+  showModal: () => void 0,
+  hideModal: () => void 0
 })

--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -7,6 +7,14 @@
 
 import * as React from 'react'
 
+declare global {
+  interface Window {
+    bugsnagClient?: {
+      notify?(e: unknown): void
+    }
+  }
+}
+
 /**
  * Modals are represented as react components
  *
@@ -23,9 +31,22 @@ export interface ModalContextType {
 }
 
 /**
+ * Throw error when ModalContext is used outside of context provider
+ */
+const invariantViolation = () => {
+  if (window.bugsnagClient && typeof window.bugsnagClient.notify === 'function') {
+    window.bugsnagClient.notify(
+      new Error(
+        'Attempted to call useModal outside of modal context. Make sure your app is rendered inside ModalProvider.'
+      )
+    )
+  }
+}
+
+/**
  * Modal Context Object
  */
 export const ModalContext = React.createContext<ModalContextType>({
-  showModal: () => void 0,
-  hideModal: () => void 0
+  showModal: invariantViolation,
+  hideModal: invariantViolation
 })

--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -22,6 +22,9 @@ declare global {
  */
 export type ModalType = React.FunctionComponent<any>
 
+export const ERR_MSG =
+  'Attempted to call useModal outside of modal context. Make sure your app is rendered inside ModalProvider.'
+
 /**
  * The shape of the modal context
  */
@@ -35,11 +38,7 @@ export interface ModalContextType {
  */
 const invariantViolation = () => {
   if (window.bugsnagClient && typeof window.bugsnagClient.notify === 'function') {
-    window.bugsnagClient.notify(
-      new Error(
-        'Attempted to call useModal outside of modal context. Make sure your app is rendered inside ModalProvider.'
-      )
-    )
+    window.bugsnagClient.notify(new Error(ERR_MSG))
   }
 }
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
