### PR TITLE
fix: [PL 20548]: Center align Placeholder of tags component

### DIFF
--- a/src/components/FormikForm/FormikForm.css
+++ b/src/components/FormikForm/FormikForm.css
@@ -80,7 +80,7 @@
       }
 
       .bp3-tag-input-values {
-        margin: 1px 7px 2px 1px !important;
+        margin: 2px 7px 0 1px !important;
       }
     }
 

--- a/src/components/FormikForm/FormikForm.tsx
+++ b/src/components/FormikForm/FormikForm.tsx
@@ -144,7 +144,7 @@ function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
     label,
     ...rest
   } = restProps
-  const [mentionsType] = React.useState(`kv-tag-input-${name}}`)
+  const [mentionsType] = React.useState(`kv-tag-input-${name}`)
 
   return (
     <FormGroup


### PR DESCRIPTION
**Summary**
Center align Placeholder of tags component

**Jira Links:**
https://harness.atlassian.net/browse/PL-20548

**Screenshots:**

**Before:**
![image](https://user-images.githubusercontent.com/96057095/152298672-2b791b81-5e3b-4b73-9d24-6b74fc13d8f6.png)

**After:**
![image](https://user-images.githubusercontent.com/96057095/152298378-70cb520e-7d98-47ee-8142-f9fc46fddd5e.png)

**Before:**
![image](https://user-images.githubusercontent.com/96057095/152298534-d4fdc89f-b85a-4544-b980-d0608d8320db.png)

**After:**
![image](https://user-images.githubusercontent.com/96057095/152298484-fe295402-a6cc-49c4-b5b5-0f1f290cd3fa.png)


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
