### PR TITLE
fix: [PIE-2227]: spacing for Multiselect inside of FormikForm

### DIFF
--- a/src/components/FormikForm/FormikForm.css
+++ b/src/components/FormikForm/FormikForm.css
@@ -110,7 +110,8 @@
     .bp3-input-ghost {
       font-size: 14px;
       line-height: 22px;
-      padding-top: 2px;
+      margin-top: 3px;
+      margin-bottom: 3px;
     }
 
     .bp3-tag-input .bp3-tag {
@@ -118,6 +119,7 @@
       line-height: 22px;
       font-size: 14px;
       margin-top: 3px;
+      margin-bottom: 3px;
     }
   }
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
