### PR TITLE
fix: [PIE-2265]: allow string as other tooltip type in ThumbnailSelect component

### DIFF
--- a/src/components/ThumbnailSelect/ThumbnailSelect.tsx
+++ b/src/components/ThumbnailSelect/ThumbnailSelect.tsx
@@ -25,7 +25,7 @@ export interface Item {
   icon?: IconName
   value: string
   disabled?: boolean
-  tooltip?: ReactElement
+  tooltip?: ReactElement | string
   tooltipProps?: PopoverProps
 }
 


### PR DESCRIPTION
Currently because tooltip prop does not have string as one of the type, typescript throws error while passing string values.
Internally, ThumbnailSelect component does make use of string tooltip value and displays tooltip. But, no consumer can pass string values which makes functionality non-usable.

JIRA - https://harness.atlassian.net/browse/PIE-2265


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
