### PR TITLE
feat: [PIE-1735]: Add name as required prop to FormError

### DIFF
--- a/src/components/CollapsableSelect/CollapsableSelect.tsx
+++ b/src/components/CollapsableSelect/CollapsableSelect.tsx
@@ -66,7 +66,7 @@ export function CollapsableSelect<T>(props: ConnectedCollapsableSelectProps<T>) 
 
   const hasError = errorCheck(name, formik)
   const intent = hasError ? Intent.DANGER : Intent.NONE
-  const helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null
+  const helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} name={name} /> : null
 
   function handleChangeClick(): void {
     setShowAllOptions(true)

--- a/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -212,6 +212,7 @@ exports[`<DateInput/> tests renders with invalid value and allow variables 1`] =
       </div>
       <div
         class="errorDiv"
+        data-name=""
       >
         <span
           class="bp3-icon main errorTextIcon intent intent-danger"

--- a/src/components/FormError/FormError.tsx
+++ b/src/components/FormError/FormError.tsx
@@ -11,19 +11,19 @@ import cx from 'classnames'
 import { Icon } from '../../icons/Icon'
 import css from './FormError.css'
 
-export const FormError = ({
-  errorMessage,
-  className
-}: {
+interface FormErrorProps {
   errorMessage: string | undefined | FormikErrors<any>
+  name: string
   className?: string
-}) => {
+}
+
+export const FormError = ({ errorMessage, className, name }: FormErrorProps): React.ReactElement | null => {
   if (!errorMessage) {
     return null
   }
   // Used to display form errors below the fields, with an icon
   return (
-    <div className={cx(css.errorDiv, className)}>
+    <div data-name={name} className={cx(css.errorDiv, className)}>
       <Icon name="circle-cross" className={css.errorTextIcon} size={12} intent="danger" />
       <span className={css.error}>{errorMessage}</span>
     </div>

--- a/src/components/FormikForm/DurationInput.tsx
+++ b/src/components/FormikForm/DurationInput.tsx
@@ -27,7 +27,7 @@ export function DurationInput(props: DurationInputProps & FormikContextProps<any
 
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} name={name} /> : null,
     disabled,
     ...rest
   } = restProps

--- a/src/components/FormikForm/FormikForm.tsx
+++ b/src/components/FormikForm/FormikForm.tsx
@@ -86,7 +86,7 @@ function TagInput<T>(props: TagInputProps<T> & FormikContextProps<any>) {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items,
     label,
@@ -138,7 +138,7 @@ function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     label,
@@ -204,7 +204,7 @@ function MultiInput(props: MultiInputProps & FormikContextProps<any>) {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     label,
@@ -252,7 +252,7 @@ const CustomRender = (props: CustomRenderProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     label,
@@ -290,7 +290,7 @@ const FileInput = (props: FileInputProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     placeholder = i18n.chooseFile,
@@ -347,7 +347,7 @@ const RadioGroup = (props: RadioGroupProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     items = [],
@@ -392,7 +392,7 @@ const CheckBox = (props: CheckboxProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     onChange,
@@ -430,7 +430,7 @@ const Toggle = (props: ToggleProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     onChange,
     className = '',
@@ -470,7 +470,7 @@ const MultiSelect = (props: MultiSelectProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items,
     label,
@@ -538,7 +538,7 @@ const Select = (props: SelectProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items,
     label,
@@ -603,7 +603,7 @@ const DropDown = (props: DropDownFormikProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items,
     addClearBtn,
@@ -653,7 +653,7 @@ const Text = (props: TextProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     inputGroup,
@@ -710,7 +710,7 @@ const ExpressionInput = (props: ExpressionInputProps & FormikContextProps<any>) 
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     label,
     inline = formik?.inline,
@@ -756,7 +756,7 @@ const TextArea = (props: TextAreaProps & FormikContextProps<any>) => {
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     inline = formik?.inline,
     placeholder,
@@ -905,7 +905,7 @@ const FormColorPicker = (props: FormColorPickerProps & FormikContextProps<any>) 
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     onChange,
     label,
@@ -950,7 +950,7 @@ const FormMultiTypeInput = (props: FormMultiTypeInputProps & FormikContextProps<
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     label,
     ...rest
@@ -1039,7 +1039,7 @@ const FormMultiSelectTypeInput = (props: FormMultiSelectTypeInputProps & FormikC
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     label,
     ...rest
@@ -1111,7 +1111,7 @@ const FormMultiTextTypeInput = (props: FormMultiTextTypeInputProps & FormikConte
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     label,
     ...rest
@@ -1179,7 +1179,7 @@ const FormCategorizedSelect = (props: FormCategorizedSelect & FormikContextProps
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items = [],
     label,
@@ -1238,7 +1238,7 @@ const FormSelectWithSubview = (props: FormSelectWithSubviewProps & FormikContext
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items = [],
     label,
@@ -1303,7 +1303,7 @@ const FormMultiSelectWithSubview = (props: FormMultiSelectWithSubviewProps & For
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
-    helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null,
+    helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null,
     disabled = formik?.disabled,
     items = [],
     placeholder,

--- a/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
+++ b/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
@@ -54,7 +54,7 @@ const GroupedThumbnailSelect: React.FC<ConnectedGroupedThumbnailSelectProps> = p
 
   const hasError = errorCheck(name, formik)
   const intent = hasError ? Intent.DANGER : Intent.NONE
-  const helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null
+  const helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null
 
   React.useEffect(() => {
     setShowAllOptions(isEmpty(value))

--- a/src/components/InputWithIdentifier/InputWithIdentifier.tsx
+++ b/src/components/InputWithIdentifier/InputWithIdentifier.tsx
@@ -137,10 +137,11 @@ export const InputWithIdentifier: React.FC<InputWithIdentifierProps> = props => 
         }}
       />
       {!formik.errors[inputName] && formik.errors[idName] ? (
-        <FormError className={css.idError} errorMessage={get(formik.errors, idName)} />
+        <FormError name={idName} className={css.idError} errorMessage={get(formik.errors, idName)} />
       ) : null}
       {formik.values[currentEditField]?.length >= maxInput ? (
         <FormError
+          name={currentEditField === idName ? idLabel : inputLabel}
           errorMessage={`Limit of ${maxInput} characters is reached for ${
             currentEditField === idName ? idLabel : inputLabel
           }`}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -87,7 +87,7 @@ export function TextInput(props: TextInputProps): React.ReactElement {
         leftIcon={leftIcon && <Icon name={leftIcon} size={12} {...leftIconProps} />}
         rightElement={rightElem}
       />
-      {hasError && !errorInPopover && errorText ? <FormError errorMessage={errorText} /> : null}
+      {hasError && !errorInPopover && errorText ? <FormError name={rest.name ?? ''} errorMessage={errorText} /> : null}
     </div>
   )
 }

--- a/src/components/ThumbnailSelect/ThumbnailSelect.tsx
+++ b/src/components/ThumbnailSelect/ThumbnailSelect.tsx
@@ -67,7 +67,7 @@ const ThumbnailSelect: React.FC<ConnectedThumbnailSelectProps> = props => {
 
   const hasError = errorCheck(name, formik)
   const intent = hasError ? Intent.DANGER : Intent.NONE
-  const helperText = hasError ? <FormError errorMessage={get(formik?.errors, name)} /> : null
+  const helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null
 
   React.useEffect(() => {
     setShowAllOptions(isEmpty(value) || expandAllByDefault)


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
