### PR TITLE
fix: [PL-21624]: added tooltip for the ability to see the full name of a lengthy tag

### DIFF
--- a/src/components/FormikForm/__tests__/FormikForm.test.tsx
+++ b/src/components/FormikForm/__tests__/FormikForm.test.tsx
@@ -46,7 +46,9 @@ const renderFormikFormWithoutFormName = (
     </Formik>
   )
 }
-const findPopoverWrapperContainer = (): HTMLElement | null => document.querySelector('.bp3-popover-wrapper')
+
+// '.select' class for inner 'bp3-popover-wrapper' container
+const findPopoverWrapperContainer = (): HTMLElement | null => document.querySelector('.bp3-popover-wrapper.select')
 
 describe('Test basic Components', () => {
   test('should render Text component', () => {

--- a/src/components/FormikForm/__tests__/FormikForm.test.tsx
+++ b/src/components/FormikForm/__tests__/FormikForm.test.tsx
@@ -46,6 +46,7 @@ const renderFormikFormWithoutFormName = (
     </Formik>
   )
 }
+const findPopoverWrapperContainer = (): HTMLElement | null => document.querySelector('.bp3-popover-wrapper')
 
 describe('Test basic Components', () => {
   test('should render Text component', () => {
@@ -337,7 +338,8 @@ describe('Test basic Components', () => {
       fireEvent.click(addButton!)
     })
     expect((inputSelect as any).value).toBe('customvalue') // selected value A
-    expect(container).toMatchSnapshot()
+    const popoverWrapper = findPopoverWrapperContainer()
+    expect(popoverWrapper).toMatchSnapshot()
   })
   test('should render MultiTypeInput component with Select', async () => {
     const selectItems = [
@@ -388,7 +390,8 @@ describe('Test basic Components', () => {
       fireEvent.click(addButton!)
     })
     expect((inputSelect as any).value).toBe('customvalue') // selected value A
-    expect(container).toMatchSnapshot()
+    const popoverWrapper = findPopoverWrapperContainer()
+    expect(popoverWrapper).toMatchSnapshot()
   })
 
   test('Tag Input component type duplicate values CDNG-8531', async () => {

--- a/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
+++ b/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
@@ -590,271 +590,129 @@ exports[`Test basic Components should render MultiSelect component 1`] = `
 `;
 
 exports[`Test basic Components should render MultiTypeInput component with Select (with useValue and selectItems) 1`] = `
-<div>
+<div
+  class="bp3-popover-wrapper bp3-fill"
+>
   <div
-    class="overlaySpinner"
+    class="bp3-popover-target"
   >
-    <form
-      class="main"
+    <div
+      class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
     >
-      <div>
+      <div
+        class="bp3-popover-target"
+      >
         <div
-          class="bp3-form-group"
-          data-id="label-multitypeinput-0"
+          class="bp3-input-group"
         >
-          <label
-            class="bp3-label"
-            for="label-multitypeinput"
-          >
-            <span
-              class="acenter"
-              data-tooltip-id="testform_label-multitypeinput"
-            >
-              select
-            </span>
-             
-            <span
-              class="bp3-text-muted"
-            />
-          </label>
-          <div
-            class="bp3-form-content"
-          >
-            <div
-              class="horizontal layout-spacing-undefined main width width-undefined"
-            >
-              <div
-                class="bp3-popover-wrapper bp3-fill"
-              >
-                <div
-                  class="bp3-popover-target"
-                >
-                  <div
-                    class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
-                  >
-                    <div
-                      class="bp3-popover-target"
-                    >
-                      <div
-                        class="bp3-input-group"
-                      >
-                        <input
-                          autocomplete="off"
-                          class="bp3-input"
-                          name="label-multitypeinput"
-                          placeholder="Search..."
-                          style="padding-right: 0px;"
-                          type="text"
-                          value="customvalue"
-                        />
-                        <span
-                          class="bp3-input-action"
-                        >
-                          <span
-                            class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
-                            data-icon="main-delete"
-                          >
-                            <svg
-                              height="14"
-                              width="14"
-                            />
-                          </span>
-                          <span
-                            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                            icon="chevron-down"
-                          >
-                            <svg
-                              data-icon="chevron-down"
-                              height="14"
-                              viewBox="0 0 16 16"
-                              width="14"
-                            >
-                              <desc>
-                                chevron-down
-                              </desc>
-                              <path
-                                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <span
-                class="bp3-popover-wrapper wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="btn FIXED"
-                  >
-                    <span
-                      class="bp3-icon main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        width="12"
-                      />
-                    </span>
-                  </button>
-                </span>
-              </span>
-            </div>
-          </div>
-        </div>
-        <button
-          class="bp3-button button font main intent intent-primary with-current-color"
-          type="submit"
-        >
+          <input
+            autocomplete="off"
+            class="bp3-input"
+            name="label-multitypeinput"
+            placeholder="Search..."
+            style="padding-right: 0px;"
+            type="text"
+            value="customvalue"
+          />
           <span
-            class="bp3-button-text"
+            class="bp3-input-action"
           >
-            Submit
+            <span
+              class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
+              data-icon="main-delete"
+            >
+              <svg
+                height="14"
+                width="14"
+              />
+            </span>
+            <span
+              class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height="14"
+                viewBox="0 0 16 16"
+                width="14"
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
           </span>
-        </button>
+        </div>
       </div>
-    </form>
+    </div>
   </div>
 </div>
 `;
 
 exports[`Test basic Components should render MultiTypeInput component with Select 1`] = `
-<div>
+<div
+  class="bp3-popover-wrapper bp3-fill"
+>
   <div
-    class="overlaySpinner"
+    class="bp3-popover-target"
   >
-    <form
-      class="main"
+    <div
+      class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
     >
-      <div>
+      <div
+        class="bp3-popover-target"
+      >
         <div
-          class="bp3-form-group"
-          data-id="label-multitypeinput-0"
+          class="bp3-input-group"
         >
-          <label
-            class="bp3-label"
-            for="label-multitypeinput"
-          >
-            <span
-              class="acenter"
-              data-tooltip-id="testform_label-multitypeinput"
-            >
-              select
-            </span>
-             
-            <span
-              class="bp3-text-muted"
-            />
-          </label>
-          <div
-            class="bp3-form-content"
-          >
-            <div
-              class="horizontal layout-spacing-undefined main width width-undefined"
-            >
-              <div
-                class="bp3-popover-wrapper bp3-fill"
-              >
-                <div
-                  class="bp3-popover-target"
-                >
-                  <div
-                    class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
-                  >
-                    <div
-                      class="bp3-popover-target"
-                    >
-                      <div
-                        class="bp3-input-group"
-                      >
-                        <input
-                          autocomplete="off"
-                          class="bp3-input"
-                          name="label-multitypeinput"
-                          placeholder="Search..."
-                          style="padding-right: 0px;"
-                          type="text"
-                          value="customvalue"
-                        />
-                        <span
-                          class="bp3-input-action"
-                        >
-                          <span
-                            class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
-                            data-icon="main-delete"
-                          >
-                            <svg
-                              height="14"
-                              width="14"
-                            />
-                          </span>
-                          <span
-                            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                            icon="chevron-down"
-                          >
-                            <svg
-                              data-icon="chevron-down"
-                              height="14"
-                              viewBox="0 0 16 16"
-                              width="14"
-                            >
-                              <desc>
-                                chevron-down
-                              </desc>
-                              <path
-                                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <span
-                class="bp3-popover-wrapper wrapper"
-              >
-                <span
-                  class="bp3-popover-target"
-                >
-                  <button
-                    class="btn FIXED"
-                  >
-                    <span
-                      class="bp3-icon main"
-                      data-icon="fixed-input"
-                    >
-                      <svg
-                        height="12"
-                        width="12"
-                      />
-                    </span>
-                  </button>
-                </span>
-              </span>
-            </div>
-          </div>
-        </div>
-        <button
-          class="bp3-button button font main intent intent-primary with-current-color"
-          type="submit"
-        >
+          <input
+            autocomplete="off"
+            class="bp3-input"
+            name="label-multitypeinput"
+            placeholder="Search..."
+            style="padding-right: 0px;"
+            type="text"
+            value="customvalue"
+          />
           <span
-            class="bp3-button-text"
+            class="bp3-input-action"
           >
-            Submit
+            <span
+              class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
+              data-icon="main-delete"
+            >
+              <svg
+                height="14"
+                width="14"
+              />
+            </span>
+            <span
+              class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+              icon="chevron-down"
+            >
+              <svg
+                data-icon="chevron-down"
+                height="14"
+                viewBox="0 0 16 16"
+                width="14"
+              >
+                <desc>
+                  chevron-down
+                </desc>
+                <path
+                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
           </span>
-        </button>
+        </div>
       </div>
-    </form>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
+++ b/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
@@ -905,54 +905,46 @@ exports[`Test basic Components should render Select component 1`] = `
             class="bp3-form-content"
           >
             <div
-              class="bp3-popover-wrapper bp3-fill"
+              class="bp3-popover-wrapper main bp3-fill"
             >
               <div
                 class="bp3-popover-target"
               >
                 <div
-                  class="bp3-popover-wrapper main bp3-fill"
+                  class="bp3-input-group"
                 >
-                  <div
-                    class="bp3-popover-target"
+                  <input
+                    autocomplete="off"
+                    class="bp3-input"
+                    name="color"
+                    placeholder="- Select -"
+                    style="padding-right: 0px;"
+                    type="text"
+                    value=""
+                  />
+                  <span
+                    class="bp3-input-action"
                   >
-                    <div
-                      class="bp3-input-group"
+                    <span
+                      class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                      icon="chevron-down"
                     >
-                      <input
-                        autocomplete="off"
-                        class="bp3-input"
-                        name="color"
-                        placeholder="- Select -"
-                        style="padding-right: 0px;"
-                        type="text"
-                        value=""
-                      />
-                      <span
-                        class="bp3-input-action"
+                      <svg
+                        data-icon="chevron-down"
+                        height="14"
+                        viewBox="0 0 16 16"
+                        width="14"
                       >
-                        <span
-                          class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                          icon="chevron-down"
-                        >
-                          <svg
-                            data-icon="chevron-down"
-                            height="14"
-                            viewBox="0 0 16 16"
-                            width="14"
-                          >
-                            <desc>
-                              chevron-down
-                            </desc>
-                            <path
-                              d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
+                        <desc>
+                          chevron-down
+                        </desc>
+                        <path
+                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
+++ b/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
@@ -591,63 +591,55 @@ exports[`Test basic Components should render MultiSelect component 1`] = `
 
 exports[`Test basic Components should render MultiTypeInput component with Select (with useValue and selectItems) 1`] = `
 <div
-  class="bp3-popover-wrapper bp3-fill"
+  class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
 >
   <div
     class="bp3-popover-target"
   >
     <div
-      class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
+      class="bp3-input-group"
     >
-      <div
-        class="bp3-popover-target"
+      <input
+        autocomplete="off"
+        class="bp3-input"
+        name="label-multitypeinput"
+        placeholder="Search..."
+        style="padding-right: 0px;"
+        type="text"
+        value="customvalue"
+      />
+      <span
+        class="bp3-input-action"
       >
-        <div
-          class="bp3-input-group"
+        <span
+          class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
+          data-icon="main-delete"
         >
-          <input
-            autocomplete="off"
-            class="bp3-input"
-            name="label-multitypeinput"
-            placeholder="Search..."
-            style="padding-right: 0px;"
-            type="text"
-            value="customvalue"
+          <svg
+            height="14"
+            width="14"
           />
-          <span
-            class="bp3-input-action"
+        </span>
+        <span
+          class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+          icon="chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="14"
+            viewBox="0 0 16 16"
+            width="14"
           >
-            <span
-              class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
-              data-icon="main-delete"
-            >
-              <svg
-                height="14"
-                width="14"
-              />
-            </span>
-            <span
-              class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height="14"
-                viewBox="0 0 16 16"
-                width="14"
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
+            <desc>
+              chevron-down
+            </desc>
+            <path
+              d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </span>
     </div>
   </div>
 </div>
@@ -655,63 +647,55 @@ exports[`Test basic Components should render MultiTypeInput component with Selec
 
 exports[`Test basic Components should render MultiTypeInput component with Select 1`] = `
 <div
-  class="bp3-popover-wrapper bp3-fill"
+  class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
 >
   <div
     class="bp3-popover-target"
   >
     <div
-      class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
+      class="bp3-input-group"
     >
-      <div
-        class="bp3-popover-target"
+      <input
+        autocomplete="off"
+        class="bp3-input"
+        name="label-multitypeinput"
+        placeholder="Search..."
+        style="padding-right: 0px;"
+        type="text"
+        value="customvalue"
+      />
+      <span
+        class="bp3-input-action"
       >
-        <div
-          class="bp3-input-group"
+        <span
+          class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
+          data-icon="main-delete"
         >
-          <input
-            autocomplete="off"
-            class="bp3-input"
-            name="label-multitypeinput"
-            placeholder="Search..."
-            style="padding-right: 0px;"
-            type="text"
-            value="customvalue"
+          <svg
+            height="14"
+            width="14"
           />
-          <span
-            class="bp3-input-action"
+        </span>
+        <span
+          class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+          icon="chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="14"
+            viewBox="0 0 16 16"
+            width="14"
           >
-            <span
-              class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
-              data-icon="main-delete"
-            >
-              <svg
-                height="14"
-                width="14"
-              />
-            </span>
-            <span
-              class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-              icon="chevron-down"
-            >
-              <svg
-                data-icon="chevron-down"
-                height="14"
-                viewBox="0 0 16 16"
-                width="14"
-              >
-                <desc>
-                  chevron-down
-                </desc>
-                <path
-                  d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-      </div>
+            <desc>
+              chevron-down
+            </desc>
+            <path
+              d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </span>
     </div>
   </div>
 </div>

--- a/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
+++ b/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
@@ -624,55 +624,63 @@ exports[`Test basic Components should render MultiTypeInput component with Selec
               class="horizontal layout-spacing-undefined main width width-undefined"
             >
               <div
-                class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
+                class="bp3-popover-wrapper bp3-fill"
               >
                 <div
                   class="bp3-popover-target"
                 >
                   <div
-                    class="bp3-input-group"
+                    class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
                   >
-                    <input
-                      autocomplete="off"
-                      class="bp3-input"
-                      name="label-multitypeinput"
-                      placeholder="Search..."
-                      style="padding-right: 0px;"
-                      type="text"
-                      value="customvalue"
-                    />
-                    <span
-                      class="bp3-input-action"
+                    <div
+                      class="bp3-popover-target"
                     >
-                      <span
-                        class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
-                        data-icon="main-delete"
+                      <div
+                        class="bp3-input-group"
                       >
-                        <svg
-                          height="14"
-                          width="14"
+                        <input
+                          autocomplete="off"
+                          class="bp3-input"
+                          name="label-multitypeinput"
+                          placeholder="Search..."
+                          style="padding-right: 0px;"
+                          type="text"
+                          value="customvalue"
                         />
-                      </span>
-                      <span
-                        class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                        icon="chevron-down"
-                      >
-                        <svg
-                          data-icon="chevron-down"
-                          height="14"
-                          viewBox="0 0 16 16"
-                          width="14"
+                        <span
+                          class="bp3-input-action"
                         >
-                          <desc>
-                            chevron-down
-                          </desc>
-                          <path
-                            d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                    </span>
+                          <span
+                            class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
+                            data-icon="main-delete"
+                          >
+                            <svg
+                              height="14"
+                              width="14"
+                            />
+                          </span>
+                          <span
+                            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                            icon="chevron-down"
+                          >
+                            <svg
+                              data-icon="chevron-down"
+                              height="14"
+                              viewBox="0 0 16 16"
+                              width="14"
+                            >
+                              <desc>
+                                chevron-down
+                              </desc>
+                              <path
+                                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -751,55 +759,63 @@ exports[`Test basic Components should render MultiTypeInput component with Selec
               class="horizontal layout-spacing-undefined main width width-undefined"
             >
               <div
-                class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
+                class="bp3-popover-wrapper bp3-fill"
               >
                 <div
                   class="bp3-popover-target"
                 >
                   <div
-                    class="bp3-input-group"
+                    class="bp3-popover-wrapper select fixedValueInput main bp3-fill"
                   >
-                    <input
-                      autocomplete="off"
-                      class="bp3-input"
-                      name="label-multitypeinput"
-                      placeholder="Search..."
-                      style="padding-right: 0px;"
-                      type="text"
-                      value="customvalue"
-                    />
-                    <span
-                      class="bp3-input-action"
+                    <div
+                      class="bp3-popover-target"
                     >
-                      <span
-                        class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
-                        data-icon="main-delete"
+                      <div
+                        class="bp3-input-group"
                       >
-                        <svg
-                          height="14"
-                          width="14"
+                        <input
+                          autocomplete="off"
+                          class="bp3-input"
+                          name="label-multitypeinput"
+                          placeholder="Search..."
+                          style="padding-right: 0px;"
+                          type="text"
+                          value="customvalue"
                         />
-                      </span>
-                      <span
-                        class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                        icon="chevron-down"
-                      >
-                        <svg
-                          data-icon="chevron-down"
-                          height="14"
-                          viewBox="0 0 16 16"
-                          width="14"
+                        <span
+                          class="bp3-input-action"
                         >
-                          <desc>
-                            chevron-down
-                          </desc>
-                          <path
-                            d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                    </span>
+                          <span
+                            class="bp3-icon main padding padding-top padding-top-small padding-right padding-right-xsmall padding-bottom padding-bottom-small"
+                            data-icon="main-delete"
+                          >
+                            <svg
+                              height="14"
+                              width="14"
+                            />
+                          </span>
+                          <span
+                            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                            icon="chevron-down"
+                          >
+                            <svg
+                              data-icon="chevron-down"
+                              height="14"
+                              viewBox="0 0 16 16"
+                              width="14"
+                            >
+                              <desc>
+                                chevron-down
+                              </desc>
+                              <path
+                                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1047,46 +1063,54 @@ exports[`Test basic Components should render Select component 1`] = `
             class="bp3-form-content"
           >
             <div
-              class="bp3-popover-wrapper main bp3-fill"
+              class="bp3-popover-wrapper bp3-fill"
             >
               <div
                 class="bp3-popover-target"
               >
                 <div
-                  class="bp3-input-group"
+                  class="bp3-popover-wrapper main bp3-fill"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="color"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value=""
-                  />
-                  <span
-                    class="bp3-input-action"
+                  <div
+                    class="bp3-popover-target"
                   >
-                    <span
-                      class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                      icon="chevron-down"
+                    <div
+                      class="bp3-input-group"
                     >
-                      <svg
-                        data-icon="chevron-down"
-                        height="14"
-                        viewBox="0 0 16 16"
-                        width="14"
+                      <input
+                        autocomplete="off"
+                        class="bp3-input"
+                        name="color"
+                        placeholder="- Select -"
+                        style="padding-right: 0px;"
+                        type="text"
+                        value=""
+                      />
+                      <span
+                        class="bp3-input-action"
                       >
-                        <desc>
-                          chevron-down
-                        </desc>
-                        <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </span>
+                        <span
+                          class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                          icon="chevron-down"
+                        >
+                          <svg
+                            data-icon="chevron-down"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            width="14"
+                          >
+                            <desc>
+                              chevron-down
+                            </desc>
+                            <path
+                              d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -138,3 +138,13 @@
     right: 0;
   }
 }
+
+.tooltipContainer {
+  padding: var(--spacing-medium);
+  max-width: 500px;
+  max-height: 500px;
+  overflow: auto;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -221,7 +221,7 @@ export function Select(props: SelectProps): React.ReactElement {
       content={tooltipContent}
       isDark={true}
       fill={true}
-      popoverClassName={cx(Classes.DARK)}
+      popoverClassName={Classes.DARK}
       position="bottom">
       <Suggest
         inputValueRenderer={opt => opt.label}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -207,72 +207,80 @@ export function Select(props: SelectProps): React.ReactElement {
       )
   }
   return (
-    <Suggest
-      inputValueRenderer={opt => opt.label}
-      itemRenderer={(item: SelectOption, props: IItemRendererProps) =>
-        itemRenderer?.(item, props) || defaultItemRenderer(item, props, size)
-      }
-      itemListPredicate={(query, items) =>
-        items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase()))
-      }
-      createNewItemFromQuery={props.createNewItemFromQuery || createNewItemFromQuery}
-      createNewItemRenderer={props.createNewItemRenderer || createNewItemRenderer}
-      noResults={<NoMatch />}
-      {...rest}
-      inputProps={{
-        onChange(e: React.ChangeEvent<HTMLInputElement>) {
-          setQuery(e.target.value)
-        },
-        value: query,
-        placeholder: Utils.getSelectComponentPlaceholder(rest?.inputProps?.placeholder),
-        leftElement: item?.icon ? <Icon size={getIconSizeFromSelect(size)} {...item?.icon} /> : undefined,
-        rightElement: (
-          <>
-            {!props.disabled && showClearBtn ? (
+    <Utils.WrapOptionalTooltip
+      tooltip={item?.label}
+      tooltipProps={{
+        isDark: true,
+        fill: true,
+        position: 'bottom'
+      }}>
+      <Suggest
+        inputValueRenderer={opt => opt.label}
+        itemRenderer={(item: SelectOption, props: IItemRendererProps) =>
+          itemRenderer?.(item, props) || defaultItemRenderer(item, props, size)
+        }
+        itemListPredicate={(query, items) =>
+          items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase()))
+        }
+        createNewItemFromQuery={props.createNewItemFromQuery || createNewItemFromQuery}
+        createNewItemRenderer={props.createNewItemRenderer || createNewItemRenderer}
+        noResults={<NoMatch />}
+        {...rest}
+        inputProps={{
+          onChange(e: React.ChangeEvent<HTMLInputElement>) {
+            setQuery(e.target.value)
+          },
+          value: query,
+          placeholder: Utils.getSelectComponentPlaceholder(rest?.inputProps?.placeholder),
+          leftElement: item?.icon ? <Icon size={getIconSizeFromSelect(size)} {...item?.icon} /> : undefined,
+          rightElement: (
+            <>
+              {!props.disabled && showClearBtn ? (
+                <Icon
+                  name="main-delete"
+                  onClick={(e: React.MouseEvent<HTMLHeadingElement, MouseEvent>) => {
+                    e.preventDefault()
+                    handleItemSelect({ value: '', label: '' })
+                  }}
+                  size={14}
+                  padding={{ top: 'small', right: 'xsmall', bottom: 'small' }}
+                />
+              ) : null}
               <Icon
-                name="main-delete"
-                onClick={(e: React.MouseEvent<HTMLHeadingElement, MouseEvent>) => {
-                  e.preventDefault()
-                  handleItemSelect({ value: '', label: '' })
+                name={'chevron-down'}
+                onClick={e => {
+                  const input = e.currentTarget.parentElement?.previousElementSibling as HTMLInputElement
+                  input?.focus()
                 }}
                 size={14}
-                padding={{ top: 'small', right: 'xsmall', bottom: 'small' }}
+                padding={size === SelectSize.Small ? 'xsmall' : 'small'}
               />
-            ) : null}
-            <Icon
-              name={'chevron-down'}
-              onClick={e => {
-                const input = e.currentTarget.parentElement?.previousElementSibling as HTMLInputElement
-                input?.focus()
-              }}
-              size={14}
-              padding={size === SelectSize.Small ? 'xsmall' : 'small'}
-            />
-          </>
-        ),
-        small: size === SelectSize.Small,
-        large: size === SelectSize.Large,
-        name: props.name,
-        ...props.inputProps
-      }}
-      resetOnSelect={resetOnSelect}
-      resetOnClose={resetOnClose}
-      items={loading ? [{ label: 'Loading...', value: Loading }] : items}
-      selectedItem={item}
-      onItemSelect={handleItemSelect}
-      query={query}
-      popoverProps={{
-        targetTagName: 'div',
-        wrapperTagName: 'div',
-        fill: true,
-        usePortal: !!props.usePortal,
-        minimal: true,
-        position: Position.BOTTOM_LEFT,
-        className: css.main,
-        popoverClassName: cx(css.popover, popoverClassName),
-        onClosed: whenPopoverClosed
-      }}
-    />
+            </>
+          ),
+          small: size === SelectSize.Small,
+          large: size === SelectSize.Large,
+          name: props.name,
+          ...props.inputProps
+        }}
+        resetOnSelect={resetOnSelect}
+        resetOnClose={resetOnClose}
+        items={loading ? [{ label: 'Loading...', value: Loading }] : items}
+        selectedItem={item}
+        onItemSelect={handleItemSelect}
+        query={query}
+        popoverProps={{
+          targetTagName: 'div',
+          wrapperTagName: 'div',
+          fill: true,
+          usePortal: !!props.usePortal,
+          minimal: true,
+          position: Position.BOTTOM_LEFT,
+          className: css.main,
+          popoverClassName: cx(css.popover, popoverClassName),
+          onClosed: whenPopoverClosed
+        }}
+      />
+    </Utils.WrapOptionalTooltip>
   )
 }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react'
 import cx from 'classnames'
-import { Position } from '@blueprintjs/core'
+import { Position, Classes } from '@blueprintjs/core'
 import { Suggest, ISuggestProps, IItemRendererProps } from '@blueprintjs/select'
 
 import css from './Select.css'
@@ -15,6 +15,7 @@ import { Button } from '../../components/Button/Button'
 import { Icon, IconProps } from '../../icons/Icon'
 import { Utils } from '../../core/Utils'
 import { Text } from '../../components/Text/Text'
+import { Popover } from '../../components/Popover/Popover'
 
 export interface SelectOption {
   label: string
@@ -206,14 +207,22 @@ export function Select(props: SelectProps): React.ReactElement {
         </React.Fragment>
       )
   }
+  const tooltipContent = item?.label ? (
+    <div className={css.tooltipContainer} color="white">
+      {item.label}
+    </div>
+  ) : (
+    ''
+  )
   return (
-    <Utils.WrapOptionalTooltip
-      tooltip={item?.label}
-      tooltipProps={{
-        isDark: true,
-        fill: true,
-        position: 'bottom'
-      }}>
+    <Popover
+      boundary="viewport"
+      interactionKind="hover"
+      content={tooltipContent}
+      isDark={true}
+      fill={true}
+      popoverClassName={cx(Classes.DARK)}
+      position="bottom">
       <Suggest
         inputValueRenderer={opt => opt.label}
         itemRenderer={(item: SelectOption, props: IItemRendererProps) =>
@@ -280,7 +289,7 @@ export function Select(props: SelectProps): React.ReactElement {
           onClosed: whenPopoverClosed
         }}
       />
-    </Utils.WrapOptionalTooltip>
+    </Popover>
   )
 }
 

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -3,102 +3,94 @@
 exports[`<Select/> tests basic filter works: Filtered Menu 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper bp3-fill"
+    class="bp3-popover-wrapper main bp3-fill"
   >
     <div
-      class="bp3-popover-target"
+      class="bp3-popover-target bp3-popover-open"
     >
       <div
-        class="bp3-popover-wrapper main bp3-fill"
+        class="bp3-input-group"
+      >
+        <input
+          class="bp3-input"
+          placeholder="- Select -"
+          style="padding-right: 0px;"
+          type="text"
+          value="cha"
+        />
+        <span
+          class="bp3-input-action"
+        >
+          <span
+            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+            icon="chevron-down"
+          >
+            <svg
+              data-icon="chevron-down"
+              height="14"
+              viewBox="0 0 16 16"
+              width="14"
+            >
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+    >
+      <div
+        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <div
-          class="bp3-popover-target bp3-popover-open"
+          class="bp3-popover bp3-minimal bp3-select-popover popover"
         >
           <div
-            class="bp3-input-group"
+            class="bp3-popover-content"
           >
-            <input
-              class="bp3-input"
-              placeholder="- Select -"
-              style="padding-right: 0px;"
-              type="text"
-              value="cha"
-            />
-            <span
-              class="bp3-input-action"
-            >
-              <span
-                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                icon="chevron-down"
+            <div>
+              <ul
+                class="bp3-menu"
               >
-                <svg
-                  data-icon="chevron-down"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  width="14"
+                <li
+                  class="menuItem active"
                 >
-                  <desc>
-                    chevron-down
-                  </desc>
-                  <path
-                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-        <div
-          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-        >
-          <div
-            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
-          >
-            <div
-              class="bp3-popover bp3-minimal bp3-select-popover popover"
-            >
-              <div
-                class="bp3-popover-content"
-              >
-                <div>
-                  <ul
-                    class="bp3-menu"
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
                   >
-                    <li
-                      class="menuItem active"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Charmander
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Charmeleon
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Charizard
-                      </p>
-                    </li>
-                  </ul>
-                </div>
-              </div>
+                    Charmander
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmeleon
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charizard
+                  </p>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
@@ -111,272 +103,264 @@ exports[`<Select/> tests basic filter works: Filtered Menu 1`] = `
 exports[`<Select/> tests basic filter works: Initial Menu 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper bp3-fill"
+    class="bp3-popover-wrapper main bp3-fill"
   >
     <div
-      class="bp3-popover-target"
+      class="bp3-popover-target bp3-popover-open"
     >
       <div
-        class="bp3-popover-wrapper main bp3-fill"
+        class="bp3-input-group"
+      >
+        <input
+          class="bp3-input"
+          placeholder="- Select -"
+          style="padding-right: 0px;"
+          type="text"
+          value=""
+        />
+        <span
+          class="bp3-input-action"
+        >
+          <span
+            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+            icon="chevron-down"
+          >
+            <svg
+              data-icon="chevron-down"
+              height="14"
+              viewBox="0 0 16 16"
+              width="14"
+            >
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+    >
+      <div
+        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <div
-          class="bp3-popover-target bp3-popover-open"
+          class="bp3-popover bp3-minimal bp3-select-popover popover"
         >
           <div
-            class="bp3-input-group"
+            class="bp3-popover-content"
           >
-            <input
-              class="bp3-input"
-              placeholder="- Select -"
-              style="padding-right: 0px;"
-              type="text"
-              value=""
-            />
-            <span
-              class="bp3-input-action"
-            >
-              <span
-                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                icon="chevron-down"
+            <div>
+              <ul
+                class="bp3-menu"
               >
-                <svg
-                  data-icon="chevron-down"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  width="14"
+                <li
+                  class="menuItem active"
                 >
-                  <desc>
-                    chevron-down
-                  </desc>
-                  <path
-                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-        <div
-          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-        >
-          <div
-            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
-          >
-            <div
-              class="bp3-popover bp3-minimal bp3-select-popover popover"
-            >
-              <div
-                class="bp3-popover-content"
-              >
-                <div>
-                  <ul
-                    class="bp3-menu"
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
                   >
-                    <li
-                      class="menuItem active"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Bulbasaur
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Ivysaur
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Venusaur
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Charmander
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Charmeleon
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Charizard
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Squirtle
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Wartortle
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Blastoise
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Caterpie
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Metapod
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Butterfree
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Weedle
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Kakuna
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Beedrill
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Pidgey
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Pidgeotto
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Pidgeot
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Rattata
-                      </p>
-                    </li>
-                    <li
-                      class="menuItem"
-                    >
-                      <p
-                        class="font lineclamp main menuItemLabel"
-                        style="--text-line-clamp: 1;"
-                      >
-                        Raticate
-                      </p>
-                    </li>
-                  </ul>
-                </div>
-              </div>
+                    Bulbasaur
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Ivysaur
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Venusaur
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmander
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charmeleon
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Charizard
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Squirtle
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Wartortle
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Blastoise
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Caterpie
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Metapod
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Butterfree
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Weedle
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Kakuna
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Beedrill
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Pidgey
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Pidgeotto
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Pidgeot
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Rattata
+                  </p>
+                </li>
+                <li
+                  class="menuItem"
+                >
+                  <p
+                    class="font lineclamp main menuItemLabel"
+                    style="--text-line-clamp: 1;"
+                  >
+                    Raticate
+                  </p>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
@@ -389,68 +373,60 @@ exports[`<Select/> tests basic filter works: Initial Menu 1`] = `
 exports[`<Select/> tests no matching results: Filtered Menu 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper bp3-fill"
+    class="bp3-popover-wrapper main bp3-fill"
   >
     <div
-      class="bp3-popover-target"
+      class="bp3-popover-target bp3-popover-open"
     >
       <div
-        class="bp3-popover-wrapper main bp3-fill"
+        class="bp3-input-group"
+      >
+        <input
+          class="bp3-input"
+          placeholder="- Select -"
+          style="padding-right: 0px;"
+          type="text"
+          value="abcde"
+        />
+        <span
+          class="bp3-input-action"
+        >
+          <span
+            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+            icon="chevron-down"
+          >
+            <svg
+              data-icon="chevron-down"
+              height="14"
+              viewBox="0 0 16 16"
+              width="14"
+            >
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+    >
+      <div
+        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <div
-          class="bp3-popover-target bp3-popover-open"
+          class="bp3-popover bp3-minimal bp3-select-popover popover"
         >
           <div
-            class="bp3-input-group"
+            class="bp3-popover-content"
           >
-            <input
-              class="bp3-input"
-              placeholder="- Select -"
-              style="padding-right: 0px;"
-              type="text"
-              value="abcde"
-            />
-            <span
-              class="bp3-input-action"
-            >
-              <span
-                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                icon="chevron-down"
-              >
-                <svg
-                  data-icon="chevron-down"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  width="14"
-                >
-                  <desc>
-                    chevron-down
-                  </desc>
-                  <path
-                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-        <div
-          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-        >
-          <div
-            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
-          >
-            <div
-              class="bp3-popover bp3-minimal bp3-select-popover popover"
-            >
-              <div
-                class="bp3-popover-content"
-              >
-                <div />
-              </div>
-            </div>
+            <div />
           </div>
         </div>
       </div>
@@ -462,52 +438,44 @@ exports[`<Select/> tests no matching results: Filtered Menu 1`] = `
 exports[`<Select/> tests works with async data 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper bp3-fill"
+    class="bp3-popover-wrapper main bp3-fill"
   >
     <div
       class="bp3-popover-target"
     >
       <div
-        class="bp3-popover-wrapper main bp3-fill"
+        class="bp3-input-group"
       >
-        <div
-          class="bp3-popover-target"
+        <input
+          class="bp3-input"
+          placeholder="- Select -"
+          style="padding-right: 0px;"
+          type="text"
+          value=""
+        />
+        <span
+          class="bp3-input-action"
         >
-          <div
-            class="bp3-input-group"
+          <span
+            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+            icon="chevron-down"
           >
-            <input
-              class="bp3-input"
-              placeholder="- Select -"
-              style="padding-right: 0px;"
-              type="text"
-              value=""
-            />
-            <span
-              class="bp3-input-action"
+            <svg
+              data-icon="chevron-down"
+              height="14"
+              viewBox="0 0 16 16"
+              width="14"
             >
-              <span
-                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                icon="chevron-down"
-              >
-                <svg
-                  data-icon="chevron-down"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  width="14"
-                >
-                  <desc>
-                    chevron-down
-                  </desc>
-                  <path
-                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
       </div>
     </div>
   </div>
@@ -517,77 +485,69 @@ exports[`<Select/> tests works with async data 1`] = `
 exports[`<Select/> tests works with async data: Loading state 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper bp3-fill"
+    class="bp3-popover-wrapper main bp3-fill"
   >
     <div
-      class="bp3-popover-target"
+      class="bp3-popover-target bp3-popover-open"
     >
       <div
-        class="bp3-popover-wrapper main bp3-fill"
+        class="bp3-input-group"
+      >
+        <input
+          class="bp3-input"
+          placeholder="- Select -"
+          style="padding-right: 0px;"
+          type="text"
+          value=""
+        />
+        <span
+          class="bp3-input-action"
+        >
+          <span
+            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+            icon="chevron-down"
+          >
+            <svg
+              data-icon="chevron-down"
+              height="14"
+              viewBox="0 0 16 16"
+              width="14"
+            >
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+    >
+      <div
+        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
       >
         <div
-          class="bp3-popover-target bp3-popover-open"
+          class="bp3-popover bp3-minimal bp3-select-popover popover"
         >
           <div
-            class="bp3-input-group"
+            class="bp3-popover-content"
           >
-            <input
-              class="bp3-input"
-              placeholder="- Select -"
-              style="padding-right: 0px;"
-              type="text"
-              value=""
-            />
-            <span
-              class="bp3-input-action"
-            >
-              <span
-                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                icon="chevron-down"
+            <div>
+              <ul
+                class="bp3-menu"
               >
-                <svg
-                  data-icon="chevron-down"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  width="14"
+                <li
+                  class="menuItem loading"
                 >
-                  <desc>
-                    chevron-down
-                  </desc>
-                  <path
-                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
-        <div
-          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-        >
-          <div
-            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
-          >
-            <div
-              class="bp3-popover bp3-minimal bp3-select-popover popover"
-            >
-              <div
-                class="bp3-popover-content"
-              >
-                <div>
-                  <ul
-                    class="bp3-menu"
-                  >
-                    <li
-                      class="menuItem loading"
-                    >
-                      Loading results...
-                    </li>
-                  </ul>
-                </div>
-              </div>
+                  Loading results...
+                </li>
+              </ul>
             </div>
           </div>
         </div>
@@ -600,52 +560,44 @@ exports[`<Select/> tests works with async data: Loading state 1`] = `
 exports[`<Select/> tests works with static data 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper bp3-fill"
+    class="bp3-popover-wrapper main bp3-fill"
   >
     <div
       class="bp3-popover-target"
     >
       <div
-        class="bp3-popover-wrapper main bp3-fill"
+        class="bp3-input-group"
       >
-        <div
-          class="bp3-popover-target"
+        <input
+          class="bp3-input"
+          placeholder="- Select -"
+          style="padding-right: 0px;"
+          type="text"
+          value=""
+        />
+        <span
+          class="bp3-input-action"
         >
-          <div
-            class="bp3-input-group"
+          <span
+            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+            icon="chevron-down"
           >
-            <input
-              class="bp3-input"
-              placeholder="- Select -"
-              style="padding-right: 0px;"
-              type="text"
-              value=""
-            />
-            <span
-              class="bp3-input-action"
+            <svg
+              data-icon="chevron-down"
+              height="14"
+              viewBox="0 0 16 16"
+              width="14"
             >
-              <span
-                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-                icon="chevron-down"
-              >
-                <svg
-                  data-icon="chevron-down"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  width="14"
-                >
-                  <desc>
-                    chevron-down
-                  </desc>
-                  <path
-                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-        </div>
+              <desc>
+                chevron-down
+              </desc>
+              <path
+                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
       </div>
     </div>
   </div>

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -3,94 +3,102 @@
 exports[`<Select/> tests basic filter works: Filtered Menu 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper main bp3-fill"
+    class="bp3-popover-wrapper bp3-fill"
   >
     <div
-      class="bp3-popover-target bp3-popover-open"
+      class="bp3-popover-target"
     >
       <div
-        class="bp3-input-group"
-      >
-        <input
-          class="bp3-input"
-          placeholder="- Select -"
-          style="padding-right: 0px;"
-          type="text"
-          value="cha"
-        />
-        <span
-          class="bp3-input-action"
-        >
-          <span
-            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-            icon="chevron-down"
-          >
-            <svg
-              data-icon="chevron-down"
-              height="14"
-              viewBox="0 0 16 16"
-              width="14"
-            >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-    <div
-      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-    >
-      <div
-        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+        class="bp3-popover-wrapper main bp3-fill"
       >
         <div
-          class="bp3-popover bp3-minimal bp3-select-popover popover"
+          class="bp3-popover-target bp3-popover-open"
         >
           <div
-            class="bp3-popover-content"
+            class="bp3-input-group"
           >
-            <div>
-              <ul
-                class="bp3-menu"
+            <input
+              class="bp3-input"
+              placeholder="- Select -"
+              style="padding-right: 0px;"
+              type="text"
+              value="cha"
+            />
+            <span
+              class="bp3-input-action"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                icon="chevron-down"
               >
-                <li
-                  class="menuItem active"
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
                 >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+        >
+          <div
+            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+          >
+            <div
+              class="bp3-popover bp3-minimal bp3-select-popover popover"
+            >
+              <div
+                class="bp3-popover-content"
+              >
+                <div>
+                  <ul
+                    class="bp3-menu"
                   >
-                    Charmander
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Charmeleon
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Charizard
-                  </p>
-                </li>
-              </ul>
+                    <li
+                      class="menuItem active"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Charmander
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Charmeleon
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Charizard
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -103,264 +111,272 @@ exports[`<Select/> tests basic filter works: Filtered Menu 1`] = `
 exports[`<Select/> tests basic filter works: Initial Menu 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper main bp3-fill"
+    class="bp3-popover-wrapper bp3-fill"
   >
     <div
-      class="bp3-popover-target bp3-popover-open"
+      class="bp3-popover-target"
     >
       <div
-        class="bp3-input-group"
-      >
-        <input
-          class="bp3-input"
-          placeholder="- Select -"
-          style="padding-right: 0px;"
-          type="text"
-          value=""
-        />
-        <span
-          class="bp3-input-action"
-        >
-          <span
-            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-            icon="chevron-down"
-          >
-            <svg
-              data-icon="chevron-down"
-              height="14"
-              viewBox="0 0 16 16"
-              width="14"
-            >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-    <div
-      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-    >
-      <div
-        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+        class="bp3-popover-wrapper main bp3-fill"
       >
         <div
-          class="bp3-popover bp3-minimal bp3-select-popover popover"
+          class="bp3-popover-target bp3-popover-open"
         >
           <div
-            class="bp3-popover-content"
+            class="bp3-input-group"
           >
-            <div>
-              <ul
-                class="bp3-menu"
+            <input
+              class="bp3-input"
+              placeholder="- Select -"
+              style="padding-right: 0px;"
+              type="text"
+              value=""
+            />
+            <span
+              class="bp3-input-action"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                icon="chevron-down"
               >
-                <li
-                  class="menuItem active"
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
                 >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+        >
+          <div
+            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+          >
+            <div
+              class="bp3-popover bp3-minimal bp3-select-popover popover"
+            >
+              <div
+                class="bp3-popover-content"
+              >
+                <div>
+                  <ul
+                    class="bp3-menu"
                   >
-                    Bulbasaur
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Ivysaur
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Venusaur
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Charmander
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Charmeleon
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Charizard
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Squirtle
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Wartortle
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Blastoise
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Caterpie
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Metapod
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Butterfree
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Weedle
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Kakuna
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Beedrill
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Pidgey
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Pidgeotto
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Pidgeot
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Rattata
-                  </p>
-                </li>
-                <li
-                  class="menuItem"
-                >
-                  <p
-                    class="font lineclamp main menuItemLabel"
-                    style="--text-line-clamp: 1;"
-                  >
-                    Raticate
-                  </p>
-                </li>
-              </ul>
+                    <li
+                      class="menuItem active"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Bulbasaur
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Ivysaur
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Venusaur
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Charmander
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Charmeleon
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Charizard
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Squirtle
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Wartortle
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Blastoise
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Caterpie
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Metapod
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Butterfree
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Weedle
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Kakuna
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Beedrill
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Pidgey
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Pidgeotto
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Pidgeot
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Rattata
+                      </p>
+                    </li>
+                    <li
+                      class="menuItem"
+                    >
+                      <p
+                        class="font lineclamp main menuItemLabel"
+                        style="--text-line-clamp: 1;"
+                      >
+                        Raticate
+                      </p>
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -373,60 +389,68 @@ exports[`<Select/> tests basic filter works: Initial Menu 1`] = `
 exports[`<Select/> tests no matching results: Filtered Menu 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper main bp3-fill"
+    class="bp3-popover-wrapper bp3-fill"
   >
     <div
-      class="bp3-popover-target bp3-popover-open"
+      class="bp3-popover-target"
     >
       <div
-        class="bp3-input-group"
-      >
-        <input
-          class="bp3-input"
-          placeholder="- Select -"
-          style="padding-right: 0px;"
-          type="text"
-          value="abcde"
-        />
-        <span
-          class="bp3-input-action"
-        >
-          <span
-            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-            icon="chevron-down"
-          >
-            <svg
-              data-icon="chevron-down"
-              height="14"
-              viewBox="0 0 16 16"
-              width="14"
-            >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-    <div
-      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-    >
-      <div
-        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+        class="bp3-popover-wrapper main bp3-fill"
       >
         <div
-          class="bp3-popover bp3-minimal bp3-select-popover popover"
+          class="bp3-popover-target bp3-popover-open"
         >
           <div
-            class="bp3-popover-content"
+            class="bp3-input-group"
           >
-            <div />
+            <input
+              class="bp3-input"
+              placeholder="- Select -"
+              style="padding-right: 0px;"
+              type="text"
+              value="abcde"
+            />
+            <span
+              class="bp3-input-action"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+        >
+          <div
+            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+          >
+            <div
+              class="bp3-popover bp3-minimal bp3-select-popover popover"
+            >
+              <div
+                class="bp3-popover-content"
+              >
+                <div />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -438,44 +462,52 @@ exports[`<Select/> tests no matching results: Filtered Menu 1`] = `
 exports[`<Select/> tests works with async data 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper main bp3-fill"
+    class="bp3-popover-wrapper bp3-fill"
   >
     <div
       class="bp3-popover-target"
     >
       <div
-        class="bp3-input-group"
+        class="bp3-popover-wrapper main bp3-fill"
       >
-        <input
-          class="bp3-input"
-          placeholder="- Select -"
-          style="padding-right: 0px;"
-          type="text"
-          value=""
-        />
-        <span
-          class="bp3-input-action"
+        <div
+          class="bp3-popover-target"
         >
-          <span
-            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-            icon="chevron-down"
+          <div
+            class="bp3-input-group"
           >
-            <svg
-              data-icon="chevron-down"
-              height="14"
-              viewBox="0 0 16 16"
-              width="14"
+            <input
+              class="bp3-input"
+              placeholder="- Select -"
+              style="padding-right: 0px;"
+              type="text"
+              value=""
+            />
+            <span
+              class="bp3-input-action"
             >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -485,69 +517,77 @@ exports[`<Select/> tests works with async data 1`] = `
 exports[`<Select/> tests works with async data: Loading state 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper main bp3-fill"
+    class="bp3-popover-wrapper bp3-fill"
   >
     <div
-      class="bp3-popover-target bp3-popover-open"
+      class="bp3-popover-target"
     >
       <div
-        class="bp3-input-group"
-      >
-        <input
-          class="bp3-input"
-          placeholder="- Select -"
-          style="padding-right: 0px;"
-          type="text"
-          value=""
-        />
-        <span
-          class="bp3-input-action"
-        >
-          <span
-            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-            icon="chevron-down"
-          >
-            <svg
-              data-icon="chevron-down"
-              height="14"
-              viewBox="0 0 16 16"
-              width="14"
-            >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </div>
-    <div
-      class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
-    >
-      <div
-        class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
-        style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+        class="bp3-popover-wrapper main bp3-fill"
       >
         <div
-          class="bp3-popover bp3-minimal bp3-select-popover popover"
+          class="bp3-popover-target bp3-popover-open"
         >
           <div
-            class="bp3-popover-content"
+            class="bp3-input-group"
           >
-            <div>
-              <ul
-                class="bp3-menu"
+            <input
+              class="bp3-input"
+              placeholder="- Select -"
+              style="padding-right: 0px;"
+              type="text"
+              value=""
+            />
+            <span
+              class="bp3-input-action"
+            >
+              <span
+                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                icon="chevron-down"
               >
-                <li
-                  class="menuItem loading"
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
                 >
-                  Loading results...
-                </li>
-              </ul>
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="bp3-overlay bp3-overlay-open bp3-overlay-inline"
+        >
+          <div
+            class="bp3-transition-container bp3-popover-appear bp3-popover-appear-active"
+            style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+          >
+            <div
+              class="bp3-popover bp3-minimal bp3-select-popover popover"
+            >
+              <div
+                class="bp3-popover-content"
+              >
+                <div>
+                  <ul
+                    class="bp3-menu"
+                  >
+                    <li
+                      class="menuItem loading"
+                    >
+                      Loading results...
+                    </li>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -560,44 +600,52 @@ exports[`<Select/> tests works with async data: Loading state 1`] = `
 exports[`<Select/> tests works with static data 1`] = `
 <div>
   <div
-    class="bp3-popover-wrapper main bp3-fill"
+    class="bp3-popover-wrapper bp3-fill"
   >
     <div
       class="bp3-popover-target"
     >
       <div
-        class="bp3-input-group"
+        class="bp3-popover-wrapper main bp3-fill"
       >
-        <input
-          class="bp3-input"
-          placeholder="- Select -"
-          style="padding-right: 0px;"
-          type="text"
-          value=""
-        />
-        <span
-          class="bp3-input-action"
+        <div
+          class="bp3-popover-target"
         >
-          <span
-            class="bp3-icon bp3-icon-chevron-down main padding padding-small"
-            icon="chevron-down"
+          <div
+            class="bp3-input-group"
           >
-            <svg
-              data-icon="chevron-down"
-              height="14"
-              viewBox="0 0 16 16"
-              width="14"
+            <input
+              class="bp3-input"
+              placeholder="- Select -"
+              style="padding-right: 0px;"
+              type="text"
+              value=""
+            />
+            <span
+              class="bp3-input-action"
             >
-              <desc>
-                chevron-down
-              </desc>
-              <path
-                d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down main padding padding-small"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Summary:**
Added tooltip for the ability to see the full name of a lengthy tag (Note: this is NOT the Blueprint Tag-Input component)

**Jira Links:**

https://harness.atlassian.net/browse/PL-21624


**Screenshots:**

Before:
![image](https://user-images.githubusercontent.com/96057095/153829727-e65524f6-3080-4c61-a16f-717edda120d3.png)


After:
<img width="556" alt="image" src="https://user-images.githubusercontent.com/96057095/153829774-f0dbd9cc-666c-4fee-9345-54cf363ed1b5.png">



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
