### PR TITLE
feat: [PIE-1735]: Git Commit the fix for multitype on firefox/safari

### DIFF
--- a/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -168,15 +168,15 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
           )
         }
         onClick={ev => {
-          if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
-            /*
-            PIE-1755
-            https://github.com/palantir/blueprint/issues/3856
-            Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
-            So checking the event pointer type, and stopping the propagation if not clicked by the user
-            */
-            ev.stopPropagation()
-          }
+          // if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
+          //   /*
+          //   PIE-1755
+          //   https://github.com/palantir/blueprint/issues/3856
+          //   Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
+          //   So checking the event pointer type, and stopping the propagation if not clicked by the user
+          //   */
+          //   ev.stopPropagation()
+          // }
           ev.preventDefault()
         }}
         disabled={disabled}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
