### PR TITLE
fix: [PL-23050]: Fixed dialog width

### DIFF
--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -57,7 +57,7 @@
     }
   }
   .bp3-dialog.bp3-dialog {
-    /* Default width in blueprint library is 500px. "min-width" prevents any wider dialogue from going below this value */
+    /* Default width in blueprint library is 500px. "min-width" prevents any wider dialog from going below this value */
     min-width: 500px;
     width: auto;
   }

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -57,6 +57,8 @@
     }
   }
   .bp3-dialog.bp3-dialog {
+    /* Default width in blueprint library is 500px. "min-width" prevents any wider dialogue from going below this value */
+    min-width: 500px;
     width: auto;
   }
 }


### PR DESCRIPTION
Summary:
This dialog resizing bug was introduced with this PR: https://github.com/harness/uicore/pull/591 meant to fix it for wider dialogs.
Added `min-width` to fix this for narrower dialogs that rely on default value from Blueprint library.
Default width in blueprint library is 500px. "min-width" prevents any wider dialog from going below this value

JIRA:
https://harness.atlassian.net/browse/PL-23050

Screenshots:

Before:
<img width="682" alt="image" src="https://user-images.githubusercontent.com/96057095/154478903-face3310-063e-4d07-8a12-c2ea99c79b79.png">

After:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/96057095/154478949-7493b3d6-c4b8-45ac-a563-32398c73c7aa.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
