### PR TITLE
fix: [PL-23087]: Removed left border from modals

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -7,7 +7,6 @@
 
 .dialog {
   border-radius: 5px;
-  border-left: 0px !important;
   box-shadow: none !important;
   background: var(--white) !important;
   padding: var(--dialog-padding);

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -8,7 +8,6 @@
 :global {
   .bp3-portal {
     .bp3-dialog {
-      border-left: 20px solid var(--blue-500);
       box-shadow: none;
       background: var(--white);
       .bp3-dialog-header {


### PR DESCRIPTION
**Summary:**

Left border is visible in Modals. Both Anjan's and Maddy's [changes](https://github.com/harness/harness-core-ui/commit/699b022fe025d4fa866e1ba2da02a4be1a8f9030) are causing this. Anjan's changes have been around for 2 years (check src/modules/cv/components/MetricsVerificationModal/MetricsVerificationModal.module.scss in the commit)
With GLOBAL and !important—these changes overrode [Maddy's changes](https://github.com/harness/uicore/commit/edbfef8b43756e648e870cd78e73bb29fa369024).

Now that Anjan has moved the CSS from global to local [in this commit](https://github.com/harness/harness-core-ui/commit/06a46bcfaac9822fe4bad89afbe71b36f5d0a431), Maddy's changes are visible.

This PR is an undo of Maddy's changes

**JIRA:**
https://harness.atlassian.net/browse/PL-23087

**Screenshots:**

Before:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/96057095/154961157-b82f31d4-eed1-4d68-bc4b-ee24adfd954f.png">


After:
<img width="562" alt="image" src="https://user-images.githubusercontent.com/96057095/154960553-31bd7c70-b82d-49b4-b38d-ce74f75bc959.png">


BEFORE:
<img width="764" alt="image" src="https://user-images.githubusercontent.com/96057095/154961307-656da7f5-58e1-4dec-9526-f35942df25aa.png">

AFTER:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/96057095/154961730-6ac85dd5-5a28-4457-baaf-e810c800ce4d.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
