### PR TITLE
fix: [PIE-2699]: portal select popover has no styling

### DIFF
--- a/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -201,6 +201,7 @@ export function MultiTypeInputFixedTypeComponent(
   const { items = [] } = selectProps || {}
   return (
     <Select
+      usePortal={true}
       {...selectProps}
       className={cx(css.select, selectProps.className, {
         [css.fixedValueInput]: MultiTypeInputType.FIXED ? true : false

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -65,6 +65,13 @@
     }
   }
 
+  :global(.icon-container) {
+    position: absolute;
+    right: 0;
+  }
+}
+
+.popover {
   & :global(.bp3-transition-container),
   & :global(.bp3-popover) {
     width: 100%;
@@ -73,7 +80,7 @@
   }
 
   & :global(.bp3-menu) {
-    max-height: 350px;
+    max-height: 300px;
     width: 100%;
     overflow: auto;
     border-radius: var(--spacing-2);
@@ -83,6 +90,7 @@
     border: 0.5px solid rgba(0, 0, 0, 0.1);
     box-sizing: border-box;
     box-shadow: 0px 0px 1px rgb(40 41 61 / 4%), 0px 2px 4px rgb(96 97 112 / 16%);
+    min-width: 250px;
   }
 
   & .menuItem {
@@ -131,10 +139,5 @@
     &:hover {
       background: var(--primary-1);
     }
-  }
-
-  :global(.icon-container) {
-    position: absolute;
-    right: 0;
   }
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
