### PR TITLE
Add support for showcloseButton, canOutsideClickClose and canEscapeKeyClose props to useConfirmationDialog

### DIFF
--- a/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -37,6 +37,7 @@ export interface ConfirmationDialogProps extends Omit<IDialogProps, 'onClose' | 
   confirmButtonText?: React.ReactNode
   onClose?: (isConfirmed: boolean) => void
   customButtons?: React.ReactNode
+  showCloseButton?: boolean
 }
 
 const confirmDialogProps: Partial<IDialogProps> = {
@@ -58,6 +59,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
     confirmButtonText,
     onClose,
     customButtons,
+    showCloseButton = true,
     ...rest
   } = props
 
@@ -71,9 +73,11 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
 
   return (
     <Dialog className={css.dialog} {...confirmDialogProps} {...rest} onClose={closeWithFalse}>
-      <Container flex className={css.iconContainer}>
-        <Icon onClick={closeWithFalse} className={css.icon} size={8} name="main-close" />
-      </Container>
+      {showCloseButton ? (
+        <Container flex className={css.iconContainer}>
+          <Icon onClick={closeWithFalse} className={css.icon} size={8} name="main-close" />
+        </Container>
+      ) : null}
 
       <Layout.Horizontal className={css.header} padding={{ left: 'xsmall' }}>
         <Icon name={getIconForIntent(intent)} size={32} margin={{ right: 'small' }} />

--- a/src/components/ConfirmDialog/useConfirmationDialog.tsx
+++ b/src/components/ConfirmDialog/useConfirmationDialog.tsx
@@ -20,6 +20,9 @@ export interface UseConfirmationDialogProps {
   confirmButtonText?: React.ReactNode
   onCloseDialog?: (isConfirmed: boolean) => void
   customButtons?: React.ReactNode
+  showCloseButton?: boolean
+  canOutsideClickClose?: boolean
+  canEscapeKeyClose?: boolean
 }
 
 export interface UseConfirmationDialogReturn {
@@ -35,7 +38,10 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
     buttonIntent = Intent.PRIMARY,
     confirmButtonText,
     onCloseDialog,
-    customButtons
+    customButtons,
+    showCloseButton,
+    canOutsideClickClose,
+    canEscapeKeyClose
   } = props
 
   const [showModal, hideModal] = useModalHook(() => {
@@ -50,6 +56,9 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
         intent={intent}
         buttonIntent={buttonIntent}
         customButtons={customButtons}
+        showCloseButton={showCloseButton}
+        canOutsideClickClose={canOutsideClickClose}
+        canEscapeKeyClose={canEscapeKeyClose}
       />
     )
   }, [props])


### PR DESCRIPTION
…se and canEscapeKeyClose props to useConfirmationDialog

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
