### PR TITLE
fix: [PIE-3247]: Show cancel button if cancelButtonText is there

### DIFF
--- a/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -31,7 +31,7 @@ const getIconForIntent = (intent: Intent): HarnessIconName => {
 export interface ConfirmationDialogProps extends Omit<IDialogProps, 'onClose' | 'enforceFocus'> {
   titleText: React.ReactNode
   contentText: React.ReactNode
-  cancelButtonText: React.ReactNode
+  cancelButtonText?: React.ReactNode
   intent?: Intent
   buttonIntent?: ButtonProps['intent']
   confirmButtonText?: React.ReactNode
@@ -92,7 +92,9 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
       </Layout.Vertical>
       <Layout.Horizontal spacing="small">
         {confirmButtonText ? <Button intent={buttonIntent} text={confirmButtonText} onClick={closeWithTrue} /> : null}
-        <Button variation={ButtonVariation.TERTIARY} text={cancelButtonText} onClick={closeWithFalse} />
+        {cancelButtonText ? (
+          <Button variation={ButtonVariation.TERTIARY} text={cancelButtonText} onClick={closeWithFalse} />
+        ) : null}
         {customButtons}
       </Layout.Horizontal>
     </Dialog>

--- a/src/components/ConfirmDialog/useConfirmationDialog.tsx
+++ b/src/components/ConfirmDialog/useConfirmationDialog.tsx
@@ -27,6 +27,7 @@ export interface UseConfirmationDialogProps {
 
 export interface UseConfirmationDialogReturn {
   openDialog: () => void
+  closeDialog: () => void
 }
 
 export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseConfirmationDialogReturn => {
@@ -72,6 +73,7 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
   )
 
   return {
-    openDialog: () => showModal()
+    openDialog: () => showModal(),
+    closeDialog: () => hideModal()
   }
 }

--- a/src/components/ConfirmDialog/useConfirmationDialog.tsx
+++ b/src/components/ConfirmDialog/useConfirmationDialog.tsx
@@ -14,7 +14,7 @@ import { ConfirmationDialog } from './ConfirmationDialog'
 export interface UseConfirmationDialogProps {
   titleText: React.ReactNode
   contentText: React.ReactNode
-  cancelButtonText: React.ReactNode
+  cancelButtonText?: React.ReactNode
   intent?: Intent
   buttonIntent?: ButtonProps['intent']
   confirmButtonText?: React.ReactNode


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
