### PR TITLE
fix: [PIE-3456]: making multi type logic backward compatible

### DIFF
--- a/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -59,7 +59,8 @@ export const isValueAnExpression = (value: string): boolean => /<\+.*>/.test(val
 
 export const getMultiTypeFromValue = (
   value: AcceptableValue | undefined = '',
-  allowableTypes?: MultiTypeInputType[]
+  allowableTypes?: MultiTypeInputType[],
+  supportListOfExpressionsBehaviour?: boolean
 ): MultiTypeInputType => {
   if (typeof value === 'boolean') {
     return MultiTypeInputType.FIXED
@@ -67,7 +68,7 @@ export const getMultiTypeFromValue = (
     value = value.toLocaleLowerCase().trim()
     if (value.startsWith(RUNTIME_INPUT_VALUE)) return MultiTypeInputType.RUNTIME
     if (isValueAnExpression(value)) return MultiTypeInputType.EXPRESSION
-  } else if (Array.isArray(value)) {
+  } else if (Array.isArray(value) && supportListOfExpressionsBehaviour) {
     // To support list of expressions
     if (value.some((item: string | MultiSelectOption) => typeof item === 'string' && isValueAnExpression(item)))
       return MultiTypeInputType.EXPRESSION


### PR DESCRIPTION
Summary -

Making multi type logic backward compatible, by default it follows the old behaviour, so that changes are not required in the CI etc files.
The boolean can be used to apply the list of expressions behaviour for all the newly added components


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
