### PR TITLE
fix: [STO-4451]: Match --purple-500 to UX Figma palette

### DIFF
--- a/src/_stories/components/Colors.tsx
+++ b/src/_stories/components/Colors.tsx
@@ -107,7 +107,7 @@ export const names = {
   '--purple-800': '#4d278f',
   '--purple-700': '#592baa',
   '--purple-600': '#6938c0',
-  '--purple-500': '#6938c0',
+  '--purple-500': '#7d4dd3',
   '--purple-400': '#ae82fc',
   '--purple-300': '#c19eff',
   '--purple-200': '#cfb4ff',


### PR DESCRIPTION
`--purple-500` is a duplicate of `--purple-600`, and differs from the UX team's Figma palette. Fixes `--purple-500` to match

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
