### PR TITLE
fix: [STO-4451]: Match --purple-500 to UX Figma palette

### DIFF
--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -133,7 +133,7 @@
   --purple-800: #4d278f;
   --purple-700: #592baa;
   --purple-600: #6938c0;
-  --purple-500: #6938c0; /* Main */
+  --purple-500: #7d4dd3; /* Main */
   --purple-400: #ae82fc;
   --purple-300: #c19eff;
   --purple-200: #cfb4ff;


### PR DESCRIPTION
Second try at getting this fixed

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
