### PR TITLE
fix: [PL-25033]: Wrap words in ModalErrorHandler

### DIFF
--- a/src/components/Modal/ModalErrorHandler.tsx
+++ b/src/components/Modal/ModalErrorHandler.tsx
@@ -76,7 +76,12 @@ export interface ModalErrorHandlerProps {
   style?: React.CSSProperties
 }
 
-const breakWorkStyle = { overflowWrap: 'break-word', wordWrap: 'break-word', hyphens: 'auto' } as React.CSSProperties
+const breakWorkStyle = {
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
+  whiteSpace: 'pre-wrap'
+} as React.CSSProperties
+
 const DEFAULT_ICON_NAME = 'warning-sign'
 
 function renderMessage(message: string | React.ReactElement, color: Color) {


### PR DESCRIPTION
### JIRA:
https://harness.atlassian.net/browse/PL-25033

### Screenshots:

BEFORE
<img width="513" alt="image" src="https://user-images.githubusercontent.com/96057095/168448100-1d68d14c-8888-4a3a-8031-c0328ef64c48.png">


AFTER
<img width="521" alt="image" src="https://user-images.githubusercontent.com/96057095/168448088-8d426d0a-7e27-49c1-aa64-a925d80a061f.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
