### PR TITLE
chore: [PL-25566]: Move usePortal prop to Select component

### DIFF
--- a/src/components/FormikForm/FormikForm.tsx
+++ b/src/components/FormikForm/FormikForm.tsx
@@ -561,9 +561,9 @@ const Select = (props: SelectProps & FormikContextProps<any>) => {
       intent={intent}
       disabled={disabled}
       inline={inline}
-      usePortal={!!props.usePortal}
       {...rest}>
       <UiKitSelect
+        usePortal={!!props.usePortal}
         name={name}
         addClearBtn={props.addClearButton || false}
         inputProps={{


### PR DESCRIPTION
This PR fixes an issue whereby the `usePortal` prop of the `FormInput.Select` component was passed to the `FormGroup` component instead of the `Select` component.

Refs [PL-25566](https://harness.atlassian.net/browse/PL-25566)
