### PR TITLE
fix: externals config in webpack

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -83,7 +83,6 @@
     "typescript": "^4.1.3",
     "webpack": "^5.41.0",
     "webpack-cli": "^4.7.2",
-    "webpack-node-externals": "^3.0.0",
     "yup": "^0.32.8"
   },
   "files": [

--- a/packages/uicore/webpack.config.js
+++ b/packages/uicore/webpack.config.js
@@ -10,10 +10,13 @@
 //
 
 const path = require('path')
-const nodeExternals = require('webpack-node-externals')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const packageJSON = require('./package.json')
+const TerserPlugin = require('terser-webpack-plugin')
 const isDev = process.env.NODE_ENV === 'development'
+
+const externals = Object.keys(packageJSON.peerDependencies).reduce((p, c) => ({ ...p, [c]: `commonjs ${c}` }), {})
 
 module.exports = {
   mode: isDev ? 'development' : 'production',
@@ -86,7 +89,7 @@ module.exports = {
     libraryTarget: 'umd'
   },
 
-  externals: [nodeExternals()],
+  externals,
 
   plugins: [
     new MiniCssExtractPlugin({

--- a/packages/uicore/webpack.config.js
+++ b/packages/uicore/webpack.config.js
@@ -13,7 +13,6 @@ const path = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const packageJSON = require('./package.json')
-const TerserPlugin = require('terser-webpack-plugin')
 const isDev = process.env.NODE_ENV === 'development'
 
 const externals = Object.keys(packageJSON.peerDependencies).reduce((p, c) => ({ ...p, [c]: `commonjs ${c}` }), {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -16478,11 +16478,6 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-node-externals@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
-  integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
-
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"


### PR DESCRIPTION
We were using `webpack-node-externals` package to mark any dependencies which are external. This works well for a repo where the modules are not hoisted, but not in a monorepo setup, as it checks for `node_modules` at the same level as the config file. Hence we need to handle it ourselves now.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
