### PR TITLE
feat: [PL-25668]: Universal tooltipid for all id component

### DIFF
--- a/packages/uicore/src/components/InputWithIdentifier/InputWithIdentifier.tsx
+++ b/packages/uicore/src/components/InputWithIdentifier/InputWithIdentifier.tsx
@@ -51,7 +51,7 @@ export interface InputWithIdentifierProps {
   /**
    * @default true
    */
-  useSameUnversialToolTipId?: boolean
+  useUnversialToolTipId?: boolean
 }
 
 // https://harness.atlassian.net/wiki/spaces/CDNG/pages/736200458/Entity+Identifier
@@ -74,14 +74,14 @@ export const InputWithIdentifier: React.FC<InputWithIdentifierProps> = props => 
     inputGroupProps,
     isIdentifierEditable = true,
     maxInput = 63,
-    useSameUnversialToolTipId = false
+    useUnversialToolTipId = true
   } = props
   const [editable, setEditable] = useState(false)
   const [userModifiedIdentifier, setUserModifiedIdentifier] = useState(false)
   const identifier = get(formik.values, idName) as string
   const [currentEditField, setCurrentEditField] = useState(inputLabel)
   const tooltipContext = useContext(FormikTooltipContext)
-  const dataTooltipId = !useSameUnversialToolTipId
+  const dataTooltipId = !useUnversialToolTipId
     ? tooltipContext?.formName
       ? `${tooltipContext?.formName}_${idName}`
       : ''

--- a/packages/uicore/src/components/InputWithIdentifier/InputWithIdentifier.tsx
+++ b/packages/uicore/src/components/InputWithIdentifier/InputWithIdentifier.tsx
@@ -48,6 +48,10 @@ export interface InputWithIdentifierProps {
    * @default 63
    */
   maxInput?: number
+  /**
+   * @default true
+   */
+  useSameUnversialToolTipId?: boolean
 }
 
 // https://harness.atlassian.net/wiki/spaces/CDNG/pages/736200458/Entity+Identifier
@@ -69,14 +73,19 @@ export const InputWithIdentifier: React.FC<InputWithIdentifierProps> = props => 
     idName = 'identifier',
     inputGroupProps,
     isIdentifierEditable = true,
-    maxInput = 63
+    maxInput = 63,
+    useSameUnversialToolTipId = false
   } = props
   const [editable, setEditable] = useState(false)
   const [userModifiedIdentifier, setUserModifiedIdentifier] = useState(false)
   const identifier = get(formik.values, idName) as string
   const [currentEditField, setCurrentEditField] = useState(inputLabel)
   const tooltipContext = useContext(FormikTooltipContext)
-  const dataTooltipId = tooltipContext?.formName ? `${tooltipContext?.formName}_${idName}` : ''
+  const dataTooltipId = !useSameUnversialToolTipId
+    ? tooltipContext?.formName
+      ? `${tooltipContext?.formName}_${idName}`
+      : ''
+    : 'universalInputNameWithId'
 
   return (
     <div className={cx(css.txtNameContainer, textCss.main)}>


### PR DESCRIPTION
Docs team wants every ID component on UI  to have the same Tooltip. For this we added  constantTooltipID for ID component

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
