### PR TITLE
feat: [CDS-38820]: provide props in PillToggle component so that consumers show disable warning icon and tooltip

### DIFF
--- a/packages/uicore/src/components/PillToggle/PillToggle.css
+++ b/packages/uicore/src/components/PillToggle/PillToggle.css
@@ -23,6 +23,11 @@
     padding: 2px;
     border-radius: 100px;
     cursor: pointer;
+
+    .disableToggleReasonIcon {
+      margin-left: 2px;
+      margin-right: 2px;
+    }
   }
 
   .selected {

--- a/packages/uicore/src/components/PillToggle/PillToggle.css
+++ b/packages/uicore/src/components/PillToggle/PillToggle.css
@@ -37,6 +37,6 @@
   }
 
   .disabledMode {
-    pointer-events: none;
+    cursor: default;
   }
 }

--- a/packages/uicore/src/components/PillToggle/PillToggle.css
+++ b/packages/uicore/src/components/PillToggle/PillToggle.css
@@ -25,8 +25,7 @@
     cursor: pointer;
 
     .disableToggleReasonIcon {
-      margin-left: 2px;
-      margin-right: 2px;
+      margin: 0 var(--spacing-tiny);
     }
   }
 

--- a/packages/uicore/src/components/PillToggle/PillToggle.stories.tsx
+++ b/packages/uicore/src/components/PillToggle/PillToggle.stories.tsx
@@ -7,8 +7,12 @@
 
 import React from 'react'
 import type { Meta, Story } from '@storybook/react'
+import { Color } from '@harness/design-system'
 
 import { PillToggle, PillToggleProps } from './PillToggle'
+import { Container } from '../Container/Container'
+import { Layout } from '../../layouts/Layout'
+import { Text } from '../Text/Text'
 
 export default {
   title: 'Components / PillToggle',
@@ -23,5 +27,17 @@ Basic.args = {
     { label: 'Label 1', value: 'label-1' },
     { label: 'Label 2', value: 'label-2' }
   ],
-  selectedView: 'label-1'
+  selectedView: 'label-1',
+  disableToggleReasonContent: (
+    <Container padding="medium">
+      <Layout.Vertical width={325} padding={{ left: 'small' }}>
+        <Text width={284} color={Color.GREY_0} margin={{ bottom: 'small' }} font={{ size: 'normal', weight: 'light' }}>
+          The Visual Editor is disabled because of the errors in the YAML file.
+        </Text>
+        <Text width={284} color={Color.GREY_0} font={{ size: 'normal', weight: 'light' }}>
+          Fix all the errors indicated in the YAML Editor to enable the Visual mode.
+        </Text>
+      </Layout.Vertical>
+    </Container>
+  )
 }

--- a/packages/uicore/src/components/PillToggle/PillToggle.tsx
+++ b/packages/uicore/src/components/PillToggle/PillToggle.tsx
@@ -6,7 +6,11 @@
  */
 
 import React from 'react'
+import { isEmpty } from 'lodash-es'
 import cx from 'classnames'
+import { Classes, Intent, PopoverInteractionKind, Position } from '@blueprintjs/core'
+import { Icon, IconName } from '@harness/icons'
+import { Popover } from '../Popover/Popover'
 import css from './PillToggle.css'
 
 export interface PillToggleOption<T> {
@@ -20,17 +24,59 @@ export interface PillToggleProps<T> {
   onChange: (val: T) => void
   disableToggle?: boolean
   className?: string
+  disableToggleReasonIcon?: IconName
+  showDisableToggleReason?: boolean
+  disableToggleReasonContent?: React.ReactElement
 }
 
 export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement => {
-  const { selectedView, onChange, disableToggle = false, className = '', options } = props
+  const {
+    selectedView,
+    onChange,
+    disableToggle = false,
+    className = '',
+    options,
+    disableToggleReasonIcon = 'error-outline',
+    showDisableToggleReason = false,
+    disableToggleReasonContent
+  } = props
+
+  const renderInvalidIcon = () => {
+    return (
+      <Icon
+        name={disableToggleReasonIcon}
+        size={12}
+        className={css.disableToggleReasonIcon}
+        data-testid="invalid-icon"
+        intent={Intent.DANGER}
+      />
+    )
+  }
+
+  const renderInvalidBadge = (pillToggleValue: T) => {
+    if (disableToggle && showDisableToggleReason && selectedView !== pillToggleValue) {
+      if (!isEmpty(disableToggleReasonContent)) {
+        return (
+          <Popover interactionKind={PopoverInteractionKind.HOVER} position={Position.BOTTOM} className={Classes.DARK}>
+            {renderInvalidIcon()}
+            {disableToggleReasonContent}
+          </Popover>
+        )
+      }
+      return renderInvalidIcon()
+    }
+    return <></>
+  }
+
+  const applyDisableModeClass = disableToggle && (isEmpty(disableToggleReasonContent) || !showDisableToggleReason)
+
   return (
     <div className={cx(css.optionBtns, className)}>
       <div
         data-name="toggle-option-one"
         className={cx(css.item, {
           [css.selected]: selectedView === options[0].value,
-          [css.disabledMode]: disableToggle
+          [css.disabledMode]: applyDisableModeClass
         })}
         onClick={() => {
           if (selectedView === options[0].value) {
@@ -41,12 +87,13 @@ export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement =>
         tabIndex={0}
         role="button">
         {options[0].label}
+        {renderInvalidBadge(options[0].value)}
       </div>
       <div
         data-name="toggle-option-two"
         className={cx(css.item, {
           [css.selected]: selectedView === options[1].value,
-          [css.disabledMode]: disableToggle
+          [css.disabledMode]: applyDisableModeClass
         })}
         onClick={() => {
           if (selectedView === options[1].value) {
@@ -57,6 +104,7 @@ export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement =>
         tabIndex={0}
         role="button">
         {options[1].label}
+        {renderInvalidBadge(options[1].value)}
       </div>
     </div>
   )

--- a/packages/uicore/src/components/PillToggle/PillToggle.tsx
+++ b/packages/uicore/src/components/PillToggle/PillToggle.tsx
@@ -6,11 +6,14 @@
  */
 
 import React from 'react'
-import { isEmpty } from 'lodash-es'
 import cx from 'classnames'
 import { Classes, Intent, PopoverInteractionKind, Position } from '@blueprintjs/core'
 import { Icon, IconName } from '@harness/icons'
+import { Color } from '@harness/design-system'
 import { Popover } from '../Popover/Popover'
+import { Container } from '../Container/Container'
+import { Layout } from '../../layouts/Layout'
+import { Text } from '../Text/Text'
 import css from './PillToggle.css'
 
 export interface PillToggleOption<T> {
@@ -41,34 +44,38 @@ export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement =>
     disableToggleReasonContent
   } = props
 
-  const renderInvalidIcon = () => {
-    return (
-      <Icon
-        name={disableToggleReasonIcon}
-        size={12}
-        className={css.disableToggleReasonIcon}
-        data-testid="invalid-icon"
-        intent={Intent.DANGER}
-      />
-    )
-  }
-
   const renderInvalidBadge = (pillToggleValue: T) => {
     if (disableToggle && showDisableToggleReason && selectedView !== pillToggleValue) {
-      if (!isEmpty(disableToggleReasonContent)) {
-        return (
-          <Popover interactionKind={PopoverInteractionKind.HOVER} position={Position.BOTTOM} className={Classes.DARK}>
-            {renderInvalidIcon()}
-            {disableToggleReasonContent}
-          </Popover>
-        )
-      }
-      return renderInvalidIcon()
+      return (
+        <Popover interactionKind={PopoverInteractionKind.HOVER} position={Position.BOTTOM} className={Classes.DARK}>
+          <Icon
+            name={disableToggleReasonIcon}
+            size={12}
+            className={css.disableToggleReasonIcon}
+            data-testid="invalid-icon"
+            intent={Intent.DANGER}
+          />
+          {disableToggleReasonContent ?? (
+            <Container padding="medium">
+              <Layout.Vertical width={325} padding={{ left: 'small' }}>
+                <Text
+                  width={284}
+                  color={Color.GREY_0}
+                  margin={{ bottom: 'small' }}
+                  font={{ size: 'normal', weight: 'light' }}>
+                  The Visual Editor is disabled because of the errors in the YAML file.
+                </Text>
+                <Text width={284} color={Color.GREY_0} font={{ size: 'normal', weight: 'light' }}>
+                  Fix all the errors indicated in the YAML Editor to enable the Visual mode.
+                </Text>
+              </Layout.Vertical>
+            </Container>
+          )}
+        </Popover>
+      )
     }
     return <></>
   }
-
-  const applyDisableModeClass = disableToggle && (isEmpty(disableToggleReasonContent) || !showDisableToggleReason)
 
   return (
     <div className={cx(css.optionBtns, className)}>
@@ -76,10 +83,10 @@ export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement =>
         data-name="toggle-option-one"
         className={cx(css.item, {
           [css.selected]: selectedView === options[0].value,
-          [css.disabledMode]: applyDisableModeClass
+          [css.disabledMode]: disableToggle
         })}
         onClick={() => {
-          if (selectedView === options[0].value) {
+          if (selectedView === options[0].value || disableToggle) {
             return
           }
           onChange(options[0].value)
@@ -93,10 +100,10 @@ export const PillToggle = <T,>(props: PillToggleProps<T>): React.ReactElement =>
         data-name="toggle-option-two"
         className={cx(css.item, {
           [css.selected]: selectedView === options[1].value,
-          [css.disabledMode]: applyDisableModeClass
+          [css.disabledMode]: disableToggle
         })}
         onClick={() => {
-          if (selectedView === options[1].value) {
+          if (selectedView === options[1].value || disableToggle) {
             return
           }
           onChange(options[1].value)

--- a/packages/uicore/src/components/PillToggle/__tests__/PillToggle.test.tsx
+++ b/packages/uicore/src/components/PillToggle/__tests__/PillToggle.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { PillToggle } from '../PillToggle'
+import { VisualYamlSelectedView } from 'components/VisualYamlToggle/VisualYamlToggle'
+import userEvent from '@testing-library/user-event'
+
+const options = [
+  {
+    label: 'VISUAL',
+    value: VisualYamlSelectedView.VISUAL
+  },
+  {
+    label: 'YAML',
+    value: VisualYamlSelectedView.YAML
+  }
+]
+
+describe('PillToggle', () => {
+  test('snapshot testing on initial render', () => {
+    const { container } = render(
+      <PillToggle options={options as any} selectedView={VisualYamlSelectedView.VISUAL as any} onChange={jest.fn()} />
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  test('VISUAL should be selected', async () => {
+    render(
+      <PillToggle options={options as any} selectedView={VisualYamlSelectedView.VISUAL as any} onChange={jest.fn()} />
+    )
+    const visualDiv = screen.getByText('VISUAL')
+    expect(visualDiv).toHaveClass('selected')
+  })
+
+  test('YAML should be selected', async () => {
+    render(
+      <PillToggle options={options as any} selectedView={VisualYamlSelectedView.YAML as any} onChange={jest.fn()} />
+    )
+    const yamlDiv = screen.getByText('YAML')
+    expect(yamlDiv).toHaveClass('selected')
+  })
+
+  test('clicking on VISUAL should invoke onChange call', async () => {
+    const onChange = jest.fn()
+    render(
+      <PillToggle options={options as any} selectedView={VisualYamlSelectedView.YAML as any} onChange={onChange} />
+    )
+    const visualDiv = screen.getByText('VISUAL')
+    userEvent.click(visualDiv)
+    expect(onChange).toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(VisualYamlSelectedView.VISUAL)
+  })
+
+  test('clicking on VISUAL should not invoke onChange call when toggle should be disabled', async () => {
+    const onChange = jest.fn()
+    render(
+      <PillToggle
+        options={options as any}
+        selectedView={VisualYamlSelectedView.YAML as any}
+        onChange={onChange}
+        disableToggle={true}
+      />
+    )
+    const visualDiv = screen.getByText('VISUAL')
+    userEvent.click(visualDiv)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('should show disable reason icon when showDisableToggleReason is true', async () => {
+    const onChange = jest.fn()
+    const { container } = render(
+      <PillToggle
+        options={options as any}
+        selectedView={VisualYamlSelectedView.YAML as any}
+        onChange={onChange}
+        disableToggle={true}
+        showDisableToggleReason={true}
+      />
+    )
+    expect(container).toMatchSnapshot()
+    const visualDiv = screen.getByText('VISUAL')
+    userEvent.click(visualDiv)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/packages/uicore/src/components/PillToggle/__tests__/__snapshots__/PillToggle.test.tsx.snap
+++ b/packages/uicore/src/components/PillToggle/__tests__/__snapshots__/PillToggle.test.tsx.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PillToggle should show disable reason icon when showDisableToggleReason is true 1`] = `
+<div>
+  <div
+    class="optionBtns"
+  >
+    <div
+      class="item disabledMode"
+      data-name="toggle-option-one"
+      role="button"
+      tabindex="0"
+    >
+      VISUAL
+      <span
+        class="bp3-popover-wrapper bp3-dark"
+      >
+        <span
+          class="bp3-popover-target"
+        >
+          <span
+            class="bp3-icon StyledProps--main disableToggleReasonIcon StyledProps--intent-danger"
+            data-icon="error-outline"
+            data-testid="invalid-icon"
+            tabindex="0"
+          >
+            <svg
+              fill="none"
+              height="12"
+              viewBox="0 0 16 16"
+              width="12"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.423 1.631a.667.667 0 011.154 0l6.543 11.333a.667.667 0 01-.577 1H1.457a.667.667 0 01-.577-1L7.423 1.631z"
+                fill="#fff"
+              />
+              <path
+                clip-rule="evenodd"
+                d="M7.57 2.253a.5.5 0 01.869 0l5.993 10.5a.5.5 0 01-.434.747H2.011a.5.5 0 01-.434-.748L7.57 2.253zm.407 8.242c.422 0 .763.333.763.744a.754.754 0 01-.763.745.754.754 0 01-.763-.745c0-.411.341-.745.763-.745zm.5-1.498a.5.5 0 11-1 0V5.498a.5.5 0 111 0v3.499z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </div>
+    <div
+      class="item selected disabledMode"
+      data-name="toggle-option-two"
+      role="button"
+      tabindex="0"
+    >
+      YAML
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PillToggle snapshot testing on initial render 1`] = `
+<div>
+  <div
+    class="optionBtns"
+  >
+    <div
+      class="item selected"
+      data-name="toggle-option-one"
+      role="button"
+      tabindex="0"
+    >
+      VISUAL
+    </div>
+    <div
+      class="item"
+      data-name="toggle-option-two"
+      role="button"
+      tabindex="0"
+    >
+      YAML
+    </div>
+  </div>
+</div>
+`;

--- a/packages/uicore/src/components/VisualYamlToggle/VisualYamlToggle.tsx
+++ b/packages/uicore/src/components/VisualYamlToggle/VisualYamlToggle.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react'
+import { IconName } from '@harness/icons'
 import { PillToggle, PillToggleProps } from '../PillToggle/PillToggle'
 
 export enum VisualYamlSelectedView {
@@ -22,10 +23,13 @@ export interface VisualYamlToggleProps {
     visual?: string
     yaml?: string
   }
+  disableToggleReasonIcon?: IconName
+  showDisableToggleReason?: boolean
+  disableToggleReasonContent?: React.ReactElement
 }
 
 export function VisualYamlToggle(props: VisualYamlToggleProps): JSX.Element {
-  const { selectedView, onChange, disableToggle = false, className = '', labels } = props
+  const { selectedView, onChange, disableToggle = false, className = '', labels, ...restProps } = props
 
   const toggleProps: PillToggleProps<VisualYamlSelectedView> = {
     selectedView,
@@ -41,7 +45,8 @@ export function VisualYamlToggle(props: VisualYamlToggleProps): JSX.Element {
     ],
     onChange,
     disableToggle,
-    className
+    className,
+    ...restProps
   }
 
   return <PillToggle {...toggleProps} />


### PR DESCRIPTION
JIRA - https://harness.atlassian.net/browse/CDS-38820

Design Link: https://www.figma.com/file/4cqisYyQGDjzz51LyDp0Wj/Config-as-Code?node-id=3568%3A27734

Design image: 
<img width="1792" alt="Screenshot 2022-06-13 at 5 39 10 PM" src="https://user-images.githubusercontent.com/81295223/173350726-6e86e929-bb1e-4333-8d8d-97bff0429ed3.png">

**After Dev**
Storybook screenshot:
<img width="1792" alt="Screenshot 2022-06-13 at 5 27 20 PM" src="https://user-images.githubusercontent.com/81295223/173350706-6d6db76c-aa21-4bfc-8c1c-df835dac6a50.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
