### PR TITLE
fix: add display flex to SplitButton

### DIFF
--- a/packages/uicore/src/components/SplitButton/SplitButton.css
+++ b/packages/uicore/src/components/SplitButton/SplitButton.css
@@ -34,6 +34,7 @@
 
 .splitButton {
   position: relative;
+  display: flex;
   button.bp3-button {
     box-shadow: none;
   }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
