### PR TITLE
fix: pass tooltipProps to second button only in SplitButton component

### DIFF
--- a/packages/uicore/src/components/SplitButton/SplitButton.css
+++ b/packages/uicore/src/components/SplitButton/SplitButton.css
@@ -34,6 +34,7 @@
 
 .splitButton {
   position: relative;
+  display: flex;
   button.bp3-button {
     box-shadow: none;
   }

--- a/packages/uicore/src/components/SplitButton/SplitButton.tsx
+++ b/packages/uicore/src/components/SplitButton/SplitButton.tsx
@@ -19,6 +19,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
   icon,
   children,
   className,
+  tooltipProps,
   ...commonProps
 }) => {
   const [isOptionsOpen, setOptionsOpen] = React.useState(false)
@@ -43,6 +44,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
         position={Position.BOTTOM_RIGHT}>
         <Button
           rightIcon="chevron-down"
+          tooltipProps={tooltipProps}
           {...commonProps}
           onClick={() => setOptionsOpen(true)}
           className={cx(css.dropdown, className)}


### PR DESCRIPTION
Issue:
<img width="557" alt="Screenshot 2022-06-15 at 2 07 53 PM" src="https://user-images.githubusercontent.com/81295223/173783610-0077f9b1-a8f6-47bf-813c-c830423a8df7.png">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
