### PR TITLE
fix: SplitButton css specificity for secondary variation

### DIFF
--- a/packages/uicore/src/components/SplitButton/SplitButton.css
+++ b/packages/uicore/src/components/SplitButton/SplitButton.css
@@ -8,13 +8,11 @@
 .main {
   border-top-right-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
-  border-right: none !important;
 }
 
 .dropdown {
   border-top-left-radius: 0 !important;
   border-bottom-left-radius: 0 !important;
-  border-left: none !important;
   position: relative;
   &::before {
     content: '';
@@ -25,7 +23,6 @@
     top: 20%;
     background-color: var(--white);
   }
-
   &[class*='variation-secondary']::before,
   &[class*='variation-link']::before {
     background-color: var(--primary-7);
@@ -54,6 +51,14 @@
 
     .bp3-icon.bp3-icon-chevron-down {
       padding-left: 0 !important;
+    }
+
+    .border-left-0.Button--button[class*='bp3-button'] {
+      border-left: none !important;
+    }
+
+    .border-right-0.Button--button[class*='bp3-button'] {
+      border-right: none !important;
     }
   }
 }

--- a/packages/uicore/src/components/SplitButton/SplitButton.tsx
+++ b/packages/uicore/src/components/SplitButton/SplitButton.tsx
@@ -30,7 +30,13 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
 
   return (
     <div className={css.splitButton}>
-      <Button {...commonProps} onClick={handleClick} text={text} icon={icon} className={cx(css.main)} />
+      <Button
+        {...commonProps}
+        onClick={handleClick}
+        text={text}
+        icon={icon}
+        className={cx(css.main, 'border-right-0')}
+      />
       <Popover
         disabled={commonProps.disabled}
         isOpen={isOptionsOpen}
@@ -47,7 +53,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
           tooltipProps={tooltipProps}
           {...commonProps}
           onClick={() => setOptionsOpen(true)}
-          className={cx(css.dropdown, className)}
+          className={cx(css.dropdown, className, 'border-left-0')}
         />
       </Popover>
     </div>


### PR DESCRIPTION
**Before** 
<img width="148" alt="Screenshot 2022-06-20 at 3 12 57 PM" src="https://user-images.githubusercontent.com/20707504/174574757-1f8cae61-99ec-4b89-a405-788efa2802dd.png">

**After**
<img width="158" alt="Screenshot 2022-06-20 at 3 11 55 PM" src="https://user-images.githubusercontent.com/20707504/174574789-f11f1b28-973f-4426-8443-c1aba734a395.png">

