### PR TITLE
chore: [FFM-3975]: smaller and more spaced out dots for options button

### DIFF
--- a/packages/icons/src/Options.svg
+++ b/packages/icons/src/Options.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 4 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="2" cy="2.5" r="2" />
-  <circle cx="2" cy="8" r="2" />
-  <circle cx="2" cy="13.5" r="2" />
+  <circle cx="2" cy="2" r="1.5" />
+  <circle cx="2" cy="8" r="1.5" />
+  <circle cx="2" cy="14" r="1.5" />
 </svg>


### PR DESCRIPTION
Made the dots smaller and more spaced out for `Options` button

![image](https://user-images.githubusercontent.com/95680496/177533698-5271e594-d152-4b6a-86ce-171c152ebd0a.png)


- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
