### PR TITLE
fix: [PIE-4356]: move onclick target to avoid updating several tests

### DIFF
--- a/packages/uicore/src/components/TableV2/TableV2.tsx
+++ b/packages/uicore/src/components/TableV2/TableV2.tsx
@@ -167,12 +167,11 @@ export const TableV2 = <Data extends Record<string, any>>(props: TableProps<Data
                 getRowClassName?.(row)
               )}
               {...row.getRowProps()}
-              data-testid={rowDataTestID?.(row.original, row.index)}>
-              <div
-                className={css.cells}
-                onClick={() => {
-                  props.onRowClick?.(row.original, row.index)
-                }}>
+              data-testid={rowDataTestID?.(row.original, row.index)}
+              onClick={() => {
+                props.onRowClick?.(row.original, row.index)
+              }}>
+              <div className={css.cells}>
                 {row.cells.map((cell, index) => {
                   return (
                     // eslint-disable-next-line react/jsx-key


### PR DESCRIPTION
- move onclick target to avoid updating several tests
- The behavior works as is but we need to upgrade several tests to change click target. Instead of that moved onClick target to parent