### PR TITLE
fix: [PL-24388]: add PageError class

### DIFF
--- a/packages/uicore/src/components/Page/PageError.css
+++ b/packages/uicore/src/components/Page/PageError.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.pageError {
+  position: static;
+}

--- a/packages/uicore/src/components/Page/PageError.tsx
+++ b/packages/uicore/src/components/Page/PageError.tsx
@@ -9,6 +9,7 @@ import { Text, Icon, Layout, Button, ButtonVariation, ButtonProps, Container } f
 import { Color } from '@harness/design-system'
 import React from 'react'
 import i18n from './PageError.i18n'
+import css from './PageError.css'
 
 export interface PageErrorProps {
   message?: React.ReactNode
@@ -38,7 +39,7 @@ const getErrorNode = (message: React.ReactNode): React.ReactNode => {
 
 export const PageError: React.FC<PageErrorProps> = props => {
   return (
-    <Container width="100%" height="100%" flex={{ align: 'center-center' }}>
+    <Container width="100%" height="100%" flex={{ align: 'center-center' }} className={css.pageError}>
       <Layout.Vertical
         spacing="medium"
         width={props?.width || 500}

--- a/packages/uicore/src/components/Page/__tests__/__snapshots__/PageError.test.tsx.snap
+++ b/packages/uicore/src/components/Page/__tests__/__snapshots__/PageError.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PageError test Rendering error with a React Node 1`] = `
 <div>
   <div
-    class="StyledProps--font StyledProps--main StyledProps--flex StyledProps--flex-align-center-center"
+    class="StyledProps--font StyledProps--main pageError StyledProps--flex StyledProps--flex-align-center-center"
     style="width: 100%; height: 100%;"
   >
     <div
@@ -46,7 +46,7 @@ exports[`PageError test Rendering error with a React Node 1`] = `
 exports[`PageError test Rendering error with a string 1`] = `
 <div>
   <div
-    class="StyledProps--font StyledProps--main StyledProps--flex StyledProps--flex-align-center-center"
+    class="StyledProps--font StyledProps--main pageError StyledProps--flex StyledProps--flex-align-center-center"
     style="width: 100%; height: 100%;"
   >
     <div
@@ -85,7 +85,7 @@ exports[`PageError test Rendering error with a string 1`] = `
 exports[`PageError test Rendering error with no message 1`] = `
 <div>
   <div
-    class="StyledProps--font StyledProps--main StyledProps--flex StyledProps--flex-align-center-center"
+    class="StyledProps--font StyledProps--main pageError StyledProps--flex StyledProps--flex-align-center-center"
     style="width: 100%; height: 100%;"
   >
     <div


### PR DESCRIPTION
Adds a dummy class to PageError so that it can be overridden in NGUI

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
