### PR TITLE
fix: [CDS-40874]: added support for children in useConfirmationDialog

### DIFF
--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -38,6 +38,7 @@ export interface ConfirmationDialogProps extends Omit<IDialogProps, 'onClose' | 
   onClose?: (isConfirmed: boolean) => void
   customButtons?: React.ReactNode
   showCloseButton?: boolean
+  children?: JSX.Element
 }
 
 const confirmDialogProps: Partial<IDialogProps> = {
@@ -60,6 +61,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
     onClose,
     customButtons,
     showCloseButton = true,
+    children,
     ...rest
   } = props
 
@@ -90,6 +92,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
         className={css.body}>
         {contentText}
       </Layout.Vertical>
+      {children}
       <Layout.Horizontal spacing="small">
         {confirmButtonText ? <Button intent={buttonIntent} text={confirmButtonText} onClick={closeWithTrue} /> : null}
         {cancelButtonText ? (

--- a/packages/uicore/src/components/ConfirmDialog/useConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/useConfirmationDialog.tsx
@@ -23,6 +23,7 @@ export interface UseConfirmationDialogProps {
   showCloseButton?: boolean
   canOutsideClickClose?: boolean
   canEscapeKeyClose?: boolean
+  children?: JSX.Element
 }
 
 export interface UseConfirmationDialogReturn {
@@ -42,7 +43,8 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
     customButtons,
     showCloseButton,
     canOutsideClickClose,
-    canEscapeKeyClose
+    canEscapeKeyClose,
+    children
   } = props
 
   const [showModal, hideModal] = useModalHook(() => {
@@ -59,8 +61,9 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
         customButtons={customButtons}
         showCloseButton={showCloseButton}
         canOutsideClickClose={canOutsideClickClose}
-        canEscapeKeyClose={canEscapeKeyClose}
-      />
+        canEscapeKeyClose={canEscapeKeyClose}>
+        {children}
+      </ConfirmationDialog>
     )
   }, [props])
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
