### PR TITLE
fix: [PIE-4750]: grouped thumbnail select update groups on change

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.73.0",
+  "version": "3.73.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
+++ b/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
@@ -34,7 +34,7 @@ export interface GroupedThumbnailSelectProps extends Omit<ThumbnailSelectProps, 
   groups: Group[]
 }
 
-const GroupedThumbnailSelect: React.FC<ConnectedGroupedThumbnailSelectProps> = props => {
+export function GroupedThumbnailSelect(props: ConnectedGroupedThumbnailSelectProps): JSX.Element {
   const {
     name,
     formik,

--- a/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
+++ b/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
@@ -51,6 +51,7 @@ const GroupedThumbnailSelect: React.FC<ConnectedGroupedThumbnailSelectProps> = p
 
   const [showAllOptions, setShowAllOptions] = React.useState(isEmpty(value))
   const [visibleGroups, setVisibleGroups] = React.useState(groups)
+  console.log('Groups: ', groups, visibleGroups)
 
   const hasError = errorCheck(name, formik)
   const intent = hasError ? Intent.DANGER : Intent.NONE
@@ -74,7 +75,7 @@ const GroupedThumbnailSelect: React.FC<ConnectedGroupedThumbnailSelectProps> = p
         }
       }
     }
-  }, [showAllOptions])
+  }, [showAllOptions, groups])
 
   function handleChangeClick(): void {
     setShowAllOptions(true)

--- a/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
+++ b/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
@@ -51,7 +51,6 @@ const GroupedThumbnailSelect: React.FC<ConnectedGroupedThumbnailSelectProps> = p
 
   const [showAllOptions, setShowAllOptions] = React.useState(isEmpty(value))
   const [visibleGroups, setVisibleGroups] = React.useState(groups)
-  console.log('Groups: ', groups, visibleGroups)
 
   const hasError = errorCheck(name, formik)
   const intent = hasError ? Intent.DANGER : Intent.NONE


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
