### PR TITLE
chore: [CDS-41745]: add usePortal and popoverClassName to MultiSelect component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.74.4",
+  "version": "3.74.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.73.3",
+  "version": "3.74.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -468,6 +468,8 @@ export interface MultiSelectProps extends Omit<IFormGroupProps, 'labelFor'> {
   placeholder?: string
   multiSelectProps?: Omit<UiKitMultiSelectProps, 'items' | 'onChange' | 'value' | 'tagInputProps'>
   onChange?: UiKitMultiSelectProps['onChange']
+  usePortal?: UiKitMultiSelectProps['usePortal']
+  popoverClassName?: UiKitMultiSelectProps['popoverClassName']
 }
 
 const MultiSelect = (props: MultiSelectProps & FormikContextProps<any>) => {
@@ -520,6 +522,8 @@ const MultiSelect = (props: MultiSelectProps & FormikContextProps<any>) => {
           onChange?.(items)
         }}
         resetOnSelect={true}
+        usePortal={!!props.usePortal}
+        popoverClassName={props.popoverClassName}
       />
     </FormGroup>
   )

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.css
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.css
@@ -145,3 +145,52 @@
     right: 0;
   }
 }
+
+.popover {
+  & :global(.bp3-menu) {
+    max-height: 350px;
+    overflow: auto;
+    min-width: 250px;
+    width: 100%;
+    padding: 0;
+  }
+
+  & .menuItem {
+    min-height: var(--spacing-8);
+    height: fit-content;
+    padding: 0 var(--spacing-small);
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    .menuItemLabel {
+      color: var(--black);
+      font-weight: 400;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      word-break: break-all;
+    }
+
+    & .checkbox {
+      margin: 0 var(--spacing-small) 0 0;
+    }
+
+    &.active {
+      background: var(--primary-1);
+    }
+
+    &.disabled {
+      color: var(--grey-400);
+      cursor: not-allowed;
+    }
+
+    &.loading {
+      color: var(--grey-400);
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      background: var(--primary-1);
+    }
+  }
+}

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -48,6 +48,8 @@ export interface MultiSelectProps
   name?: string
   onPopoverClose?: (node: HTMLElement) => void
   disabled?: boolean
+  usePortal?: boolean
+  popoverClassName?: string
 }
 
 export function NoMatch(): React.ReactElement {
@@ -55,7 +57,7 @@ export function NoMatch(): React.ReactElement {
 }
 
 export function MultiSelect(props: MultiSelectProps): React.ReactElement {
-  const { onChange, value, items: _items, onPopoverClose, disabled, ...rest } = props
+  const { onChange, value, items: _items, onPopoverClose, disabled, popoverClassName, ...rest } = props
   const [query, setQuery] = React.useState(props.query || '')
   const [loading, setLoading] = React.useState(false)
   const [items, setItems] = React.useState<MultiSelectOption[]>(Array.isArray(_items) ? _items : [])
@@ -230,12 +232,23 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         targetTagName: 'div',
         wrapperTagName: 'div',
         fill: true,
-        usePortal: false,
+        usePortal: !!props.usePortal,
         minimal: true,
         position: Position.BOTTOM_LEFT,
         className: css.main,
-        popoverClassName: css.popover,
-        onClosed: onPopoverClose
+        popoverClassName: cx(css.popover, popoverClassName),
+        onClosed: onPopoverClose,
+        modifiers: {
+          preventOverflow: {
+            // This is required to always attach the portal to the start of the reference instead of the middle
+            escapeWithReference: !!props.usePortal
+          },
+          offset: {
+            // This is required to offset the portal after it is attached to the reference.
+            // By default the portal is positioned at top: 0, left:0 wrt it's reference
+            offset: props.usePortal ? '1 2' : 0
+          }
+        }
       }}
     />
   )


### PR DESCRIPTION
Summary:

add usePortal and popoverClassName to MultiSelect component to support dropdown opening in portal div

Screenshots:
<img width="1792" alt="Screenshot 2022-08-12 at 10 45 52 AM" src="https://user-images.githubusercontent.com/81295223/184289297-1948b0a5-c860-4031-942a-76767b499cc2.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
