### PR TITLE
fix: [PIE-5070]: width of stepwizard step name increased

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.78.0",
+  "version": "3.77.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.77.0",
+  "version": "3.78.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/StepWizard/StepWizard.tsx
+++ b/packages/uicore/src/components/StepWizard/StepWizard.tsx
@@ -333,7 +333,7 @@ export function StepWizard<SharedObject = Record<string, unknown>>(
                 <>{typeof stepName.stepName === 'string' && <span className={css.number}>{stepIndex}</span>}</>
               )}
 
-              <Text className={css.stepName} lineClamp={2} width={200}>
+              <Text className={css.stepName} lineClamp={2} width={250}>
                 {stepName.stepName}
               </Text>
               {stepName.stepSubTitle ? (
@@ -345,12 +345,12 @@ export function StepWizard<SharedObject = Record<string, unknown>>(
                       : css.stepSubTitle
                   )}
                   lineClamp={2}
-                  width={200}>
+                  width={250}>
                   {stepName.stepSubTitle}
                 </Text>
               ) : null}
               {!isNestedFirstStep && state.nestedStepWizard?.[index]?.stepIndex === 1 ? (
-                <Text className={css.stepName} lineClamp={2} width={200}>
+                <Text className={css.stepName} lineClamp={2} width={250}>
                   {subtitle}
                 </Text>
               ) : null}

--- a/packages/uicore/src/components/StepWizard/__snapshots__/StepWizard.test.tsx.snap
+++ b/packages/uicore/src/components/StepWizard/__snapshots__/StepWizard.test.tsx.snap
@@ -56,13 +56,13 @@ exports[`REnder basic Step Wizard should render with initial step 1 1`] = `
           </span>
           <p
             class="StyledProps--font lineclamp StyledProps--main stepName"
-            style="--text-line-clamp: 2; width: 200px;"
+            style="--text-line-clamp: 2; width: 250px;"
           >
             Create a New Project
           </p>
           <p
             class="StyledProps--font lineclamp StyledProps--main stepName"
-            style="--text-line-clamp: 2; width: 200px;"
+            style="--text-line-clamp: 2; width: 250px;"
           >
             
           </p>
@@ -77,7 +77,7 @@ exports[`REnder basic Step Wizard should render with initial step 1 1`] = `
           </span>
           <p
             class="StyledProps--font lineclamp StyledProps--main stepName"
-            style="--text-line-clamp: 2; width: 200px;"
+            style="--text-line-clamp: 2; width: 250px;"
           >
             New Project 1
           </p>
@@ -92,7 +92,7 @@ exports[`REnder basic Step Wizard should render with initial step 1 1`] = `
           </span>
           <p
             class="StyledProps--font lineclamp StyledProps--main stepName"
-            style="--text-line-clamp: 2; width: 200px;"
+            style="--text-line-clamp: 2; width: 250px;"
           >
             Collaborator
           </p>


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks
before ->
<img width="617" alt="image" src="https://user-images.githubusercontent.com/96036463/186836463-d650c977-21e6-4e0b-b20a-e1f6763a3243.png">
after ->
<img width="618" alt="image" src="https://user-images.githubusercontent.com/96036463/186836534-a16ee1b9-b60c-4708-ba07-0a1afcdb076f.png">

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
