### PR TITLE
fix: [PL-27934]: Use intersection observer for scroll shadows, fix vertical scroll

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.79.0",
+  "version": "3.78.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.78.0",
+  "version": "3.79.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -73,17 +73,29 @@
   position: relative;
   grid-area: body;
   overflow: auto;
+}
+
+.body::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.body .bodyContent {
+  overflow: auto;
+  height: 100%;
   padding: 0 var(--spacing-huge);
 }
 
-.body.shadowTop {
+.body.shadowTop::before {
   box-shadow: var(--shadowTop);
 }
 
-.body.shadowBottom {
+.body.shadowBottom::before {
   box-shadow: var(--shadowBottom);
 }
 
-.body.shadowTopAndBottom {
+.body.shadowTopAndBottom::before {
   box-shadow: var(--shadowTop), var(--shadowBottom);
 }

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -70,12 +70,15 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 2;
 }
 
 .body .bodyContent {
   overflow: auto;
   height: 100%;
   padding: 0 var(--spacing-huge);
+  display: grid;
+  grid-template-rows: 1px 1fr 1px;
 }
 
 .noHeader.noToolbar .body .bodyContent {

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -22,20 +22,6 @@
     'footer';
 }
 
-.noHeader .body {
-  padding-top: var(--spacing-huge);
-  --showScrollTop: 0 !important;
-}
-
-.noHeader .toolbar {
-  padding-top: var(--spacing-huge);
-}
-
-.noFooter .body {
-  padding-bottom: var(--spacing-huge);
-  --showScrollBottom: 0 !important;
-}
-
 .noHeader.noFooter .body {
   background: none;
 }
@@ -58,6 +44,10 @@
 .toolbar {
   grid-area: toolbar;
   padding: 0 var(--spacing-huge) var(--spacing-large);
+}
+
+.noHeader .toolbar {
+  padding-top: var(--spacing-huge);
 }
 
 .closeButton {
@@ -86,6 +76,14 @@
   overflow: auto;
   height: 100%;
   padding: 0 var(--spacing-huge);
+}
+
+.noHeader.noToolbar .body .bodyContent {
+  padding-top: var(--spacing-huge);
+}
+
+.noFooter .body .bodyContent {
+  padding-bottom: var(--spacing-huge);
 }
 
 .body.shadowTop::before {

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -68,30 +68,22 @@
 }
 
 .body {
-  --showScrollTop: 0;
-  --showScrollBottom: 0;
+  --shadowTop: inset 0px 8px 5px -5px rgba(96, 97, 112, 0.16);
+  --shadowBottom: inset 0px -8px 5px -5px rgba(96, 97, 112, 0.16);
   position: relative;
   grid-area: body;
   overflow: auto;
   padding: 0 var(--spacing-huge);
 }
 
-.body::before,
-.body::after {
-  content: '';
-  position: sticky;
-  margin: 0 calc(-1 * var(--spacing-huge));
-  top: 0;
-  height: 1px;
-  background-color: var(--grey-200);
-  display: block;
-  opacity: calc(1 * var(--showScrollTop));
-  transition: opacity 0.15s ease-in-out;
-  z-index: 2;
+.body.shadowTop {
+  box-shadow: var(--shadowTop);
 }
 
-.body::after {
-  top: auto;
-  bottom: 0;
-  opacity: calc(1 * var(--showScrollBottom));
+.body.shadowBottom {
+  box-shadow: var(--shadowBottom);
+}
+
+.body.shadowTopAndBottom {
+  box-shadow: var(--shadowTop), var(--shadowBottom);
 }

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.test.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.test.tsx
@@ -36,15 +36,12 @@ describe('ModalDialog', () => {
       expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noHeader')
     })
 
-    test('it should not set the noHeader modifier when one of title or toolbar are omitted', async () => {
+    test('it should not set the noHeader modifier when title is passed', async () => {
       const { rerender } = renderComponent({ title: 'Test' })
       expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noHeader')
 
       rerender(<ModalDialog isOpen={true} />)
       expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noHeader')
-
-      rerender(<ModalDialog isOpen={true} toolbar="Test" />)
-      expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noHeader')
     })
   })
 
@@ -55,12 +52,19 @@ describe('ModalDialog', () => {
 
       expect(screen.getByTestId(toolbarTestId)).toBeInTheDocument()
       expect(screen.getByTestId('modaldialog-toolbar')).toBeInTheDocument()
+      expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noToolbar')
     })
 
     test('it should not include the toolbar when omitted', async () => {
       renderComponent()
 
       expect(screen.queryByTestId('modaldialog-toolbar')).not.toBeInTheDocument()
+    })
+
+    test('it should add the class noToolbar when toolbar is omitted', async () => {
+      renderComponent()
+
+      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noToolbar')
     })
   })
 

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -161,9 +161,11 @@ export const ModalDialog: FC<ModalDialogProps> = ({
       )}
 
       <div className={cx(css.body, bodyShadowClass)} data-testid="modaldialog-body" ref={bodyRef}>
-        <div ref={bodyTopEdgeRef} data-position="top" />
-        {children}
-        <div ref={bodyBottomEdgeRef} data-position="bottom" />
+        <div className={css.bodyContent}>
+          <div ref={bodyTopEdgeRef} data-position="top" />
+          {children}
+          <div ref={bodyBottomEdgeRef} data-position="bottom" />
+        </div>
       </div>
 
       {footer && (

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -70,13 +70,6 @@ export const ModalDialog: FC<ModalDialogProps> = ({
 
   const [scrollShadows, setScrollShadows] = useState({ top: false, bottom: false })
 
-  const bodyShadowClass = useMemo(() => {
-    const { top, bottom } = scrollShadows
-    if (!top && !bottom) return ''
-    if (top && bottom) return css.shadowTopAndBottom
-    return top ? css.shadowTop : css.shadowBottom
-  }, [scrollShadows])
-
   const observeEdge = useCallback((element: HTMLDivElement | null | undefined, observer: IntersectionObserver) => {
     if (!element || !observer) return
     observer.observe(element)
@@ -119,8 +112,11 @@ export const ModalDialog: FC<ModalDialogProps> = ({
 
   const modifiers = []
 
-  if (!title && !toolbar) {
+  if (!title) {
     modifiers.push(css.noHeader)
+  }
+  if (!toolbar) {
+    modifiers.push(css.noToolbar)
   }
   if (!footer) {
     modifiers.push(css.noFooter)
@@ -134,6 +130,15 @@ export const ModalDialog: FC<ModalDialogProps> = ({
     // @ts-ignore
     style['--ModalDialog-Height'] = `${height}px`
   }
+
+  const bodyShadowClass = useMemo(() => {
+    const { top, bottom } = scrollShadows
+
+    if (top && bottom && (title || toolbar) && footer) return css.shadowTopAndBottom
+    if (top && (title || toolbar)) return css.shadowTop
+    if (bottom && footer) return css.shadowBottom
+    return ''
+  }, [scrollShadows])
 
   return (
     <Dialog

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -14,6 +14,11 @@ import { Button, ButtonVariation } from '../Button/Button'
 
 import css from './ModalDialog.css'
 
+const observeEdge = (element: HTMLDivElement | null | undefined, observer: IntersectionObserver) => {
+  if (!element || !observer) return
+  observer.observe(element)
+}
+
 export interface ModalDialogProps extends IDialogProps {
   /**
    * Optional title of the modal. Can be a string or anything that React can render.
@@ -70,11 +75,6 @@ export const ModalDialog: FC<ModalDialogProps> = ({
 
   const [scrollShadows, setScrollShadows] = useState({ top: false, bottom: false })
 
-  const observeEdge = useCallback((element: HTMLDivElement | null | undefined, observer: IntersectionObserver) => {
-    if (!element || !observer) return
-    observer.observe(element)
-  }, [])
-
   const initScrollShadows = useCallback(() => {
     if (!bodyRef.current) return
 
@@ -94,7 +94,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
     )
     observeEdge(bodyTopEdgeRef.current, bodyObserverRef.current)
     observeEdge(bodyBottomEdgeRef.current, bodyObserverRef.current)
-  }, [observeEdge])
+  }, [])
 
   const onModalOpened = useCallback(
     arg => {

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -168,7 +168,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
       <div className={cx(css.body, bodyShadowClass)} data-testid="modaldialog-body" ref={bodyRef}>
         <div className={css.bodyContent}>
           <div ref={bodyTopEdgeRef} data-position="top" />
-          {children}
+          <div>{children}</div>
           <div ref={bodyBottomEdgeRef} data-position="bottom" />
         </div>
       </div>


### PR DESCRIPTION
Updates `ModalDialog` component to fix these issues:

- When the child element has height set to 100% it is causing the modal body to get a vertical scroll bar. This is because the lines (:before, :after) that are used as scroll indicators have 1px heights. So the content can only have `100%-2px` height if we want to prevent scroll bar.
- The [design](https://www.figma.com/file/bYQtU9kWVuVEsLksbVgGM4/hex2o?node-id=18966%3A154501) uses box shadows instead of lines for scroll indicators.

Changes:

- Used intersection observer instead of scroll events for displaying scroll indicators, as the observer is better for performance and also works for dynamic content. 
- Box shadows are used instead of lines.

**Before:**

short content with 100% height
<img width="548" alt="image" src="https://user-images.githubusercontent.com/52284933/188470762-0085c494-c2f8-47d9-9750-29a66bd70881.png">

long content
<img width="523" alt="image" src="https://user-images.githubusercontent.com/52284933/188473064-9db49d9f-027a-4c56-a239-6f1959361969.png">

**After:**

short content with 100% height
<img width="540" alt="image" src="https://user-images.githubusercontent.com/52284933/188473313-79b09283-4a10-49ce-9a4c-bd1cd03de49e.png">

long content
<img width="522" alt="image" src="https://user-images.githubusercontent.com/52284933/188473478-2c2db108-666a-4335-86f8-f9ab76423129.png">





You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
