### PR TITLE
feat: handle abort errors in firefox

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.78.1",
+  "version": "3.78.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/utils/errorUtils.ts
+++ b/packages/uicore/src/utils/errorUtils.ts
@@ -12,7 +12,8 @@ const IGNORED_ERRORS = [
   'Failed to fetch: Failed to fetch',
   'Failed to fetch: 504 Gateway Timeout',
   "Failed to fetch: Failed to execute 'fetch' on 'Window': The user aborted a request.",
-  'Failed to fetch: The operation was aborted.'
+  'Failed to fetch: The operation was aborted.',
+  'Failed to fetch: Fetch is aborted'
 ]
 
 export function shouldShowError(e: any): boolean {

--- a/packages/uicore/src/utils/errorUtils.ts
+++ b/packages/uicore/src/utils/errorUtils.ts
@@ -18,7 +18,7 @@ const IGNORED_ERRORS = [
 export function shouldShowError(e: any): boolean {
   const hideMessagesForStatusCodes = [502, 503]
   const message = (e?.message || '').trim()
-  if (IGNORED_ERRORS.includes(message) || hideMessagesForStatusCodes.includes(e?.status)) {
+  return !IGNORED_ERRORS.includes(message) && !hideMessagesForStatusCodes.includes(e?.status)
     return false
   }
   return true

--- a/packages/uicore/src/utils/errorUtils.ts
+++ b/packages/uicore/src/utils/errorUtils.ts
@@ -7,15 +7,18 @@
 
 import { isEmpty } from 'lodash-es'
 
+const IGNORED_ERRORS = [
+  'Failed to fetch: The user aborted a request.',
+  'Failed to fetch: Failed to fetch',
+  'Failed to fetch: 504 Gateway Timeout',
+  "Failed to fetch: Failed to execute 'fetch' on 'Window': The user aborted a request.",
+  'Failed to fetch: The operation was aborted.'
+]
+
 export function shouldShowError(e: any): boolean {
   const hideMessagesForStatusCodes = [502, 503]
-  if (
-    e?.message === 'Failed to fetch: The user aborted a request.' ||
-    e?.message === 'Failed to fetch: Failed to fetch' ||
-    e?.message === 'Failed to fetch: 504 Gateway Timeout' ||
-    e?.message === "Failed to fetch: Failed to execute 'fetch' on 'Window': The user aborted a request." ||
-    hideMessagesForStatusCodes.includes(e?.status)
-  ) {
+  const message = (e?.message || '').trim()
+  if (IGNORED_ERRORS.includes(message) || hideMessagesForStatusCodes.includes(e?.status)) {
     return false
   }
   return true

--- a/packages/uicore/src/utils/errorUtils.ts
+++ b/packages/uicore/src/utils/errorUtils.ts
@@ -18,10 +18,8 @@ const IGNORED_ERRORS = [
 export function shouldShowError(e: any): boolean {
   const hideMessagesForStatusCodes = [502, 503]
   const message = (e?.message || '').trim()
+
   return !IGNORED_ERRORS.includes(message) && !hideMessagesForStatusCodes.includes(e?.status)
-    return false
-  }
-  return true
 }
 
 /* TODO Don't see proper types for this new errors format, replace Record<string, any> with more stricter type when available */


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
