### PR TITLE
fix: [CDS-42827]: added optional prop for loading state in Select Field

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.79.1",
+  "version": "3.80.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Select/Select.css
+++ b/packages/uicore/src/components/Select/Select.css
@@ -92,11 +92,6 @@
     box-shadow: 0px 0px 1px rgb(40 41 61 / 4%), 0px 2px 4px rgb(96 97 112 / 16%);
   }
 
-  & .noResultsFound {
-    color: var(--grey-500);
-    padding: 7px 8px;
-  }
-
   :global(.icon-container) {
     position: absolute;
     right: 0;
@@ -173,4 +168,9 @@
 
 .createNewItemButton {
   padding: 5px 8px !important;
+}
+
+.noResultsFound {
+  color: var(--grey-500);
+  padding: 8px 0px 0px 7px;
 }

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -61,6 +61,7 @@ export interface SelectProps
   onQueryChange?: Props['onQueryChange']
   addTooltip?: boolean
   borderless?: boolean
+  loadingItems?: boolean
 }
 
 function getIconSizeFromSelect(size: SelectSize = SelectSize.Medium) {
@@ -131,6 +132,7 @@ export function Select(props: SelectProps): React.ReactElement {
     resetOnClose = true,
     addTooltip = false,
     borderless = false,
+    loadingItems,
     ...rest
   } = props
   const [item, setItem] = React.useState<SelectOption | undefined | null>(undefined)
@@ -182,7 +184,7 @@ export function Select(props: SelectProps): React.ReactElement {
     _active: boolean,
     handleClick: React.MouseEventHandler<HTMLElement>
   ): JSX.Element | undefined {
-    if (loading) {
+    if (loading || loadingItems) {
       return (
         <li key="loading" className={cx(css.menuItem, css.loading)}>
           Loading results...
@@ -194,7 +196,7 @@ export function Select(props: SelectProps): React.ReactElement {
       return (
         <React.Fragment>
           {items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase())).length === 0 ? (
-            <div className={css.noResultsFound}>Nothing Found</div>
+            <div className={css.noResultsFound}>No Match Found</div>
           ) : null}
           {props.allowCreatingNewItems && (
             <Button

--- a/packages/uicore/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/uicore/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -433,7 +433,7 @@ exports[`<Select/> tests no matching results: Filtered Menu 1`] = `
                 <div
                   class="noResultsFound"
                 >
-                  Nothing Found
+                  No Match Found
                 </div>
               </ul>
             </div>


### PR DESCRIPTION


https://user-images.githubusercontent.com/106532291/191431947-2148c933-eaa5-497f-829f-c263b174c013.mov

- Added additional loading prop to the Select component to show loading results instead of no results found in case of search query
- changed text from Nothing Found to No Match Found
- the scoping for the css of No Match Found was changed as it wasn't getting applied
- Attached video for reference ^^


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
