### PR TITLE
fix: [CDS-44566]: show add new item only when exact match doesn't exist (Case Sensitive)

### DIFF
--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -192,13 +192,14 @@ export function Select(props: SelectProps): React.ReactElement {
       )
     }
 
+    const isExactQueryElPresent = items.filter(item => item.label.toString() === query).length > 0
     if (!loading)
       return (
         <React.Fragment>
           {items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase())).length === 0 ? (
             <div className={css.noResultsFound}>No Match Found</div>
           ) : null}
-          {props.allowCreatingNewItems && (
+          {props.allowCreatingNewItems && !isExactQueryElPresent && (
             <Button
               intent="primary"
               minimal

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -192,7 +192,7 @@ export function Select(props: SelectProps): React.ReactElement {
       )
     }
 
-    const isExactQueryElPresent = items.filter(item => item.label.toString() === query).length > 0
+    const isExactQueryElPresent = items.some(item => item.label === query)
     if (!loading)
       return (
         <React.Fragment>


### PR DESCRIPTION

- In the select dropdown the add new icon only shows up when we don't have an element with exact case sensitive match


https://user-images.githubusercontent.com/106532291/195305966-5954c895-e176-47df-9e97-8414459fddd6.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
