### PR TITLE
fix: [CDS-44566]: no results and disabled issue for multiSelectDropdown

### DIFF
--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
@@ -7,7 +7,7 @@
 
 .main {
   &.disabled {
-    pointer-events: none;
+    cursor: not-allowed;
     .dropdownButton {
       &.withBorder {
         background-color: var(--grey-100);
@@ -63,6 +63,10 @@
         padding: 0 var(--spacing-small);
         border-radius: 10px;
         line-height: 16px;
+      }
+      .disabled {
+        background-color: var(--grey-400) !important;
+        cursor: default;
       }
     }
     &:not(.withBorder) {

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
@@ -10,7 +10,7 @@
     pointer-events: none;
     .dropdownButton {
       &.withBorder {
-        background-color: var(--grey-50);
+        background-color: var(--grey-100);
       }
       .labelWrapper {
         .label {

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
@@ -7,16 +7,19 @@
 
 .main {
   &.disabled {
-    cursor: not-allowed;
+    pointer-events: none;
     .dropdownButton {
-      &.withBorder {
-        background-color: var(--grey-100);
+      &.disabledBg {
+        background-color: var(--grey-50);
       }
       .labelWrapper {
         .label {
           color: var(--grey-400) !important;
         }
       }
+    }
+    .counter {
+      background-color: var(--grey-400) !important;
     }
   }
   .dropdownButton {
@@ -63,10 +66,6 @@
         padding: 0 var(--spacing-small);
         border-radius: 10px;
         line-height: 16px;
-      }
-      .disabled {
-        background-color: var(--grey-400) !important;
-        cursor: default;
       }
     }
     &:not(.withBorder) {

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.css
@@ -9,7 +9,7 @@
   &.disabled {
     pointer-events: none;
     .dropdownButton {
-      &.disabledBg {
+      &.withBorder {
         background-color: var(--grey-50);
       }
       .labelWrapper {

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
@@ -25,9 +25,12 @@ import { Text } from '../Text/Text'
 import { StyledProps } from '@harness/design-system'
 import { Checkbox } from '../Checkbox/Checkbox'
 import { SelectOption } from '../Select/Select'
-import { NoMatch } from '../DropDown/DropDown'
 
 type Props = IQueryListProps<MultiSelectOption>
+
+export function NoMatch(): React.ReactElement {
+  return <li className={cx(css.menuItem, css.disabled)}>No matching results found</li>
+}
 
 export interface MultiSelectDropDownProps
   extends Omit<Props, 'items' | 'selectedItems' | 'popoverProps' | 'renderer' | 'itemRenderer' | 'onItemSelect'> {
@@ -127,8 +130,6 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
     return <Menu ulRef={itemsParentRef}>{renderedItems}</Menu>
   }
 
-  const isDisabled = dropDownItems.length === 0 || !!disabled
-
   function renderer(listProps: IQueryListRendererProps<MultiSelectOption>): JSX.Element {
     return (
       <Popover
@@ -146,7 +147,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
         autoFocus={false}
         enforceFocus={false}
         onClose={() => onPopoverClose?.(selectedItems)}
-        className={cx(css.main, { [css.disabled]: isDisabled }, className)}
+        className={cx(css.main, { [css.disabled]: !!disabled }, className)}
         popoverClassName={cx(css.popover, popoverClassName)}
         isOpen={isOpen}>
         <Layout.Horizontal
@@ -166,7 +167,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
               {placeholder}
             </Text>
             {!hideItemCount && selectedItems.length > 0 && (
-              <Text className={css.counter}>
+              <Text className={cx(css.counter, { [css.disabled]: !!disabled })}>
                 {selectedItems.length <= 9 ? '0' : ''}
                 {selectedItems.length}
               </Text>

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
@@ -49,6 +49,7 @@ export interface MultiSelectDropDownProps
   placeholder?: string
   hideItemCount?: boolean
   onPopoverClose?(opts: MultiSelectOption[]): void
+  showBaseInputBlue?: boolean
 }
 
 /**
@@ -73,6 +74,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
     disabled,
     hideItemCount,
     onPopoverClose,
+    showBaseInputBlue = true,
     ...rest
   } = props
   const [selectedItems, setSelectedItems] = React.useState<MultiSelectOption[]>([])
@@ -155,9 +157,10 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
           style={width ? { width } : { minWidth }}
           className={cx(
             css.dropdownButton,
-            { [css.withBorder]: !isLabel },
-            { [css.selected]: selectedItems.length > 0 },
-            { [css.minWidth]: !width }
+            { [css.withBorder]: !isLabel && showBaseInputBlue },
+            { [css.selected]: selectedItems.length > 0 && !disabled && showBaseInputBlue },
+            { [css.minWidth]: !width },
+            { [css.disabledBg]: disabled }
           )}
           onClick={() => setIsOpen(true)}
           flex>
@@ -167,7 +170,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
               {placeholder}
             </Text>
             {!hideItemCount && selectedItems.length > 0 && (
-              <Text className={cx(css.counter, { [css.disabled]: !!disabled })}>
+              <Text className={css.counter}>
                 {selectedItems.length <= 9 ? '0' : ''}
                 {selectedItems.length}
               </Text>

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
@@ -156,7 +156,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
           className={cx(
             css.dropdownButton,
             { [css.withBorder]: !isLabel },
-            { [css.selected]: selectedItems.length > 0 && !disabled },
+            { [css.selected]: selectedItems.length > 0 },
             { [css.minWidth]: !width }
           )}
           onClick={() => setIsOpen(true)}

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
@@ -49,7 +49,6 @@ export interface MultiSelectDropDownProps
   placeholder?: string
   hideItemCount?: boolean
   onPopoverClose?(opts: MultiSelectOption[]): void
-  showBaseInputBlue?: boolean
 }
 
 /**
@@ -74,7 +73,6 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
     disabled,
     hideItemCount,
     onPopoverClose,
-    showBaseInputBlue = true,
     ...rest
   } = props
   const [selectedItems, setSelectedItems] = React.useState<MultiSelectOption[]>([])
@@ -157,10 +155,9 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
           style={width ? { width } : { minWidth }}
           className={cx(
             css.dropdownButton,
-            { [css.withBorder]: !isLabel && showBaseInputBlue },
-            { [css.selected]: selectedItems.length > 0 && !disabled && showBaseInputBlue },
-            { [css.minWidth]: !width },
-            { [css.disabledBg]: disabled }
+            { [css.withBorder]: !isLabel },
+            { [css.selected]: selectedItems.length > 0 && !disabled },
+            { [css.minWidth]: !width }
           )}
           onClick={() => setIsOpen(true)}
           flex>


### PR DESCRIPTION
1. In Multi Select Dropdown component if the dropdown items are empty the entire component was disabled
2. Instead of this added no results found dropdown
3. Count was showing as blue even if was disabled.

https://user-images.githubusercontent.com/106532291/195592826-720d2deb-1914-4fa2-9d9c-64f999dd75b3.mov




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
