### PR TITLE
fix: fix error in FileInput when multiple is falsy

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.80.2",
+  "version": "3.80.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.80.3",
+  "version": "3.81.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -288,6 +288,7 @@ export interface FileInputProps extends Omit<IFormGroupProps, 'labelFor'> {
   buttonText?: string
   onChange?: React.FormEventHandler<HTMLInputElement>
   multiple?: boolean
+  shouldSetFieldValue?: boolean
 }
 
 const FileInput = (props: FileInputProps & FormikContextProps<any>) => {
@@ -305,8 +306,23 @@ const FileInput = (props: FileInputProps & FormikContextProps<any>) => {
     onChange,
     inputProps,
     multiple = false,
+    shouldSetFieldValue = true,
     ...rest
   } = restProps
+  const value = get(formik?.values, name)
+
+  let text = placeholder
+
+  if (value) {
+    // multiple files
+    if (Array.isArray(value) && value.length) {
+      text = value.map(file => file.name).join(', ')
+    }
+    // single file
+    if (!Array.isArray(value)) {
+      text = value.name
+    }
+  }
 
   return (
     <FormGroup
@@ -329,12 +345,12 @@ const FileInput = (props: FileInputProps & FormikContextProps<any>) => {
         }}
         disabled={disabled}
         onInputChange={(e: React.FormEvent<HTMLInputElement>) => {
-          formik?.setFieldValue(name, multiple ? Array.from(e.currentTarget.files || []) : e.currentTarget.files?.[0])
+          if (shouldSetFieldValue) {
+            formik?.setFieldValue(name, multiple ? Array.from(e.currentTarget.files || []) : e.currentTarget.files?.[0])
+          }
           onChange?.(e)
         }}
-        text={get(formik?.values, name, [{ name: placeholder }])
-          .map((file: File) => file.name)
-          .join(', ')}
+        text={text}
       />
     </FormGroup>
   )


### PR DESCRIPTION
- Fixes an error related to `FileInput` placeholder caused by mapping the value when it's not an array.
- Adds a new prop to prevent formik value update on change.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
