### PR TITLE
feat: [PIE-5932]: Add explicit aria-label, when text is present (in case of icon, rightIcon, we want voiceover to read only text)

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.83.0",
+  "version": "3.84.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Button/Button.tsx
+++ b/packages/uicore/src/components/Button/Button.tsx
@@ -129,7 +129,13 @@ export function Button(props: ButtonProps): React.ReactElement {
     'size'
   )
 
-  const buttonAriaLabel = !props.text && typeof props.tooltip === 'string' ? props.tooltip : ''
+  let buttonAriaLabel = !props.text && typeof props.tooltip === 'string' ? props.tooltip : ''
+
+  // In case a Button has icon, set aria label as text
+  if (typeof props.text === 'string' && (icon || rightIcon)) {
+    buttonAriaLabel = props.text
+  }
+
   const ariaLabelProps = buttonAriaLabel ? { 'aria-label': buttonAriaLabel } : {}
 
   const button = props.noStyling ? (

--- a/packages/uicore/src/components/Button/Button.tsx
+++ b/packages/uicore/src/components/Button/Button.tsx
@@ -131,8 +131,8 @@ export function Button(props: ButtonProps): React.ReactElement {
 
   let buttonAriaLabel = !props.text && typeof props.tooltip === 'string' ? props.tooltip : ''
 
-  // In case a Button has icon, set aria label as text
-  if (typeof props.text === 'string' && (icon || rightIcon)) {
+  // In case a Button has text as a string, set aria label as text
+  if (typeof props.text === 'string') {
     buttonAriaLabel = props.text
   }
 

--- a/packages/uicore/src/components/CollapsableSelect/__snapshots__/CollapsableSelect.test.tsx.snap
+++ b/packages/uicore/src/components/CollapsableSelect/__snapshots__/CollapsableSelect.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`Test render CollapsableSelect collapsable select flow  1`] = `
             </div>
           </div>
           <button
+            aria-label="Change"
             class="bp3-button bp3-minimal button StyledProps--font StyledProps--main closeChangeBtn StyledProps--intent-primary without-shadow withLeftIcon"
             data-testid="collapsable-select-change"
             type="button"
@@ -140,6 +141,7 @@ exports[`Test render CollapsableSelect should render card view with defaultValue
             </div>
           </div>
           <button
+            aria-label="Change"
             class="bp3-button bp3-minimal button StyledProps--font StyledProps--main closeChangeBtn StyledProps--intent-primary without-shadow withLeftIcon"
             data-testid="collapsable-select-change"
             type="button"
@@ -249,6 +251,7 @@ exports[`Test render CollapsableSelect should render customView  1`] = `
             </div>
           </div>
           <button
+            aria-label="Change"
             class="bp3-button bp3-minimal button StyledProps--font StyledProps--main closeChangeBtn StyledProps--intent-primary without-shadow withLeftIcon"
             data-testid="collapsable-select-change"
             type="button"

--- a/packages/uicore/src/components/FieldArray/__snapshots__/FieldArray.test.tsx.snap
+++ b/packages/uicore/src/components/FieldArray/__snapshots__/FieldArray.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`<FieldArray /> tests render initial value when given 1`] = `
           Field List
         </span>
         <button
+          aria-label="Add"
           class="bp3-button bp3-minimal button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
           data-id="btn-add"
           type="button"
@@ -177,6 +178,7 @@ exports[`<FieldArray /> tests render placeholder when no initial value given 1`]
           This is a no data/add data message.
         </div>
         <button
+          aria-label="Add"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color withLeftIcon"
           data-id="btn-add-no-data"
           type="button"
@@ -227,6 +229,7 @@ exports[`<FieldArray /> tests should be able to add rows from both buttons 1`] =
           Field List
         </span>
         <button
+          aria-label="Add"
           class="bp3-button bp3-minimal button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
           data-id="btn-add"
           type="button"
@@ -337,6 +340,7 @@ exports[`<FieldArray /> tests should be able to add rows from both buttons 2`] =
           Field List
         </span>
         <button
+          aria-label="Add"
           class="bp3-button bp3-minimal button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
           data-id="btn-add"
           type="button"
@@ -490,6 +494,7 @@ exports[`<FieldArray /> tests should be able to delete row 1`] = `
           Field List
         </span>
         <button
+          aria-label="Add"
           class="bp3-button bp3-minimal button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
           data-id="btn-add"
           type="button"
@@ -600,6 +605,7 @@ exports[`<FieldArray /> tests should be able to render custom fields 1`] = `
           Field List
         </span>
         <button
+          aria-label="Add"
           class="bp3-button bp3-minimal button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
           data-id="btn-add"
           type="button"

--- a/packages/uicore/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
+++ b/packages/uicore/src/components/FormikForm/__tests__/__snapshots__/FormikForm.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`Test basic Components Tag Input component type duplicate values CDNG-85
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -271,6 +272,7 @@ exports[`Test basic Components should render Checkbox component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -319,6 +321,7 @@ exports[`Test basic Components should render Custom Input component 1`] = `
             class="bp3-form-content"
           >
             <button
+              aria-label="Click Me"
               class="bp3-button button StyledProps--font StyledProps--main with-current-color"
               type="button"
             >
@@ -331,6 +334,7 @@ exports[`Test basic Components should render Custom Input component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -395,6 +399,7 @@ exports[`Test basic Components should render FileInput component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -503,6 +508,7 @@ exports[`Test basic Components should render FileInput component 2`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -580,6 +586,7 @@ exports[`Test basic Components should render MultiSelect component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -793,6 +800,7 @@ exports[`Test basic Components should render RadioGroup component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -880,6 +888,7 @@ exports[`Test basic Components should render RadioGroup component in an inline f
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -974,6 +983,7 @@ exports[`Test basic Components should render Select component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -1035,6 +1045,7 @@ exports[`Test basic Components should render Text component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -1091,6 +1102,7 @@ exports[`Test basic Components should render TextArea component 1`] = `
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -1178,6 +1190,7 @@ exports[`Test basic Components should render an inline RadioGroup component 1`] 
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >
@@ -1265,6 +1278,7 @@ exports[`Test basic Components should render an inline RadioGroup component in a
           </div>
         </div>
         <button
+          aria-label="Submit"
           class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
           type="submit"
         >

--- a/packages/uicore/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/uicore/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -230,6 +230,7 @@ exports[`<MultiSelect/> tests works with filtering: Filtered Menu 1`] = `
                   </p>
                 </li>
                 <button
+                  aria-label="cha"
                   class="bp3-button bp3-minimal button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
                   type="button"
                 >

--- a/packages/uicore/src/components/Page/__tests__/__snapshots__/PageSubHeader.test.tsx.snap
+++ b/packages/uicore/src/components/Page/__tests__/__snapshots__/PageSubHeader.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`PageSubHeader test snapshot testing 1`] = `
     class="horizontal layout-spacing-undefined StyledProps--main container StyledProps--flex"
   >
     <button
+      aria-label="Add Pipeline"
       class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
       data-testid="add-pipeline"
       type="button"

--- a/packages/uicore/src/components/Pagination/__test__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/uicore/src/components/Pagination/__test__/__snapshots__/Pagination.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Pagination itemCount < pageSize 1`] = `
       class="horizontal layout-spacing-undefined StyledProps--main"
     >
       <button
+        aria-label="Prev"
         class="bp3-button bp3-disabled button StyledProps--font StyledProps--main roundedButton buttonLeft with-current-color withLeftIcon size small"
         disabled=""
         tabindex="-1"
@@ -59,6 +60,7 @@ exports[`Pagination itemCount < pageSize 1`] = `
         </span>
       </button>
       <button
+        aria-label="Next"
         class="bp3-button bp3-disabled button StyledProps--font StyledProps--main roundedButton buttonRight with-current-color withRightIcon size small"
         disabled=""
         tabindex="-1"
@@ -111,6 +113,7 @@ exports[`Pagination pageCount < 8 1`] = `
       class="horizontal layout-spacing-undefined StyledProps--main"
     >
       <button
+        aria-label="Prev"
         class="bp3-button bp3-disabled button StyledProps--font StyledProps--main roundedButton buttonLeft with-current-color withLeftIcon size small"
         disabled=""
         tabindex="-1"
@@ -174,6 +177,7 @@ exports[`Pagination pageCount < 8 1`] = `
         </span>
       </button>
       <button
+        aria-label="Next"
         class="bp3-button button StyledProps--font StyledProps--main roundedButton buttonRight with-current-color withRightIcon size small"
         type="button"
       >
@@ -224,6 +228,7 @@ exports[`Pagination pageCount >= 8 1`] = `
       class="horizontal layout-spacing-undefined StyledProps--main"
     >
       <button
+        aria-label="Prev"
         class="bp3-button bp3-disabled button StyledProps--font StyledProps--main roundedButton buttonLeft with-current-color withLeftIcon size small"
         disabled=""
         tabindex="-1"
@@ -357,6 +362,7 @@ exports[`Pagination pageCount >= 8 1`] = `
         </span>
       </button>
       <button
+        aria-label="Next"
         class="bp3-button button StyledProps--font StyledProps--main roundedButton buttonRight with-current-color withRightIcon size small"
         type="button"
       >

--- a/packages/uicore/src/components/StepWizard/__snapshots__/StepWizard.test.tsx.snap
+++ b/packages/uicore/src/components/StepWizard/__snapshots__/StepWizard.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`REnder basic Step Wizard should render with initial step 1 1`] = `
             style="height: 40px;"
           >
             <button
+              aria-label="Previous"
               class="bp3-button bp3-disabled button StyledProps--font StyledProps--main with-current-color"
               disabled=""
               tabindex="-1"
@@ -131,6 +132,7 @@ exports[`REnder basic Step Wizard should render with initial step 1 1`] = `
               </span>
             </button>
             <button
+              aria-label="Next"
               class="bp3-button button StyledProps--font StyledProps--main StyledProps--intent-primary with-current-color"
               style="float: right;"
               type="button"


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
