### PR TITLE
feat: [CDS-45863]: button with secondary intent, Secondary + intent was not available earlier

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.86.0",
+  "version": "3.87.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Button/Button.css
+++ b/packages/uicore/src/components/Button/Button.css
@@ -131,6 +131,20 @@
 
       &.variation-secondary {
         --focus-outline-color: var(--primary-7);
+        &[class*='intent-success'] {
+          border: 1px solid var(--green-800) !important;
+          color: var(--green-800) !important;
+        }
+
+        &[class*='intent-warning'] {
+          border: 1px solid var(--yellow-800) !important;
+          color: var(--yellow-800) !important;
+        }
+
+        &[class*='intent-danger'] {
+          border: 1px solid var(--red-800) !important;
+          color: var(--red-800) !important;
+        }
       }
 
       &.variation-tertiary {

--- a/packages/uicore/src/components/Button/Button.stories.tsx
+++ b/packages/uicore/src/components/Button/Button.stories.tsx
@@ -108,6 +108,20 @@ export const ButtonVariationsAndSizesExamples: Story<ButtonProps> = () => {
 
       <Container>
         <Layout.Horizontal spacing="medium">
+          <Button text="Secondary Danger" variation={ButtonVariation.SECONDARY} intent="danger" />
+          <Button text="Secondary Warning" icon="chevron-left" variation={ButtonVariation.SECONDARY} intent="warning" />
+          <Button
+            text="Secondary Warning Disabled"
+            icon="chevron-left"
+            variation={ButtonVariation.SECONDARY}
+            intent="warning"
+            disabled
+          />
+        </Layout.Horizontal>
+      </Container>
+
+      <Container>
+        <Layout.Horizontal spacing="medium">
           <Button text="Large" variation={ButtonVariation.SECONDARY} size={ButtonSize.LARGE} />
           <Button
             text="Large + left icon"


### PR DESCRIPTION
Before: 
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/20707504/200270867-378a9d39-4e4a-4731-b3b0-26f3e17edcb8.png">

After: 
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/20707504/200270579-14c46b51-fa9f-45d7-ac2b-bb0426b966d5.png">


- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
