### PR TITLE
feat: [PIE-6237]: className support for useConfirmationDialog

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.88.0",
+  "version": "3.89.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -7,6 +7,7 @@
 import React from 'react'
 
 import { Intent, Dialog, IDialogProps } from '@blueprintjs/core'
+import cx from 'classnames'
 
 import { Button, ButtonProps, Layout, Container, Icon, Text, ButtonVariation, FontVariation, Color } from '../../'
 
@@ -62,6 +63,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
     customButtons,
     showCloseButton = true,
     children,
+    className,
     ...rest
   } = props
 
@@ -74,7 +76,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
   }
 
   return (
-    <Dialog className={css.dialog} {...confirmDialogProps} {...rest} onClose={closeWithFalse}>
+    <Dialog className={cx(css.dialog, className)} {...confirmDialogProps} {...rest} onClose={closeWithFalse}>
       {showCloseButton ? (
         <Container flex className={css.iconContainer}>
           <Icon onClick={closeWithFalse} className={css.icon} size={8} name="main-close" />

--- a/packages/uicore/src/components/ConfirmDialog/useConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/useConfirmationDialog.tsx
@@ -24,6 +24,7 @@ export interface UseConfirmationDialogProps {
   canOutsideClickClose?: boolean
   canEscapeKeyClose?: boolean
   children?: JSX.Element
+  className?: string
 }
 
 export interface UseConfirmationDialogReturn {
@@ -44,7 +45,8 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
     showCloseButton,
     canOutsideClickClose,
     canEscapeKeyClose,
-    children
+    children,
+    className
   } = props
 
   const [showModal, hideModal] = useModalHook(() => {
@@ -54,6 +56,7 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
         titleText={titleText}
         contentText={contentText}
         confirmButtonText={confirmButtonText}
+        className={className}
         onClose={onClose}
         cancelButtonText={cancelButtonText}
         intent={intent}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
