### PR TITLE
fix: [PIE-5881]: resolve path of tag input field value

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.90.0",
+  "version": "3.90.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -151,6 +151,8 @@ function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
   } = restProps
   const [mentionsType] = React.useState(`kv-tag-input-${name}`)
 
+  const fieldValue = get(formik?.values, name)
+
   return (
     <FormGroup
       labelFor={name}
@@ -163,9 +165,9 @@ function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
       <BPTagInput
         values={
           isArray
-            ? formik?.values[name] || []
-            : Object.keys(formik?.values[name] || {}).map(key => {
-                const value = formik?.values[name][key]
+            ? fieldValue || []
+            : Object.keys(fieldValue || {}).map(key => {
+                const value = fieldValue[key]
                 return value ? `${key}:${value}` : key
               })
         }


### PR DESCRIPTION
Summary:

The form values for the KVTagInput field would not show up on the UI if the name path needs to be resolved. For ex: 'path1.path2.0.path3'. Added support to handle this

Now:

https://user-images.githubusercontent.com/96711906/202395898-afb22938-6b8f-44eb-a552-e0d8b3df3f83.mov

Before: 

https://user-images.githubusercontent.com/96711906/202399166-96364485-7d9c-46e2-9a63-c15e7ed44ac8.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
