### PR TITLE
fix: [SRM-12658]: externalize autoResetSortBy & autoResetPage in TableV2

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.91.2",
+  "version": "3.91.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.91.3",
+  "version": "3.92.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TableV2/TableV2.tsx
+++ b/packages/uicore/src/components/TableV2/TableV2.tsx
@@ -44,6 +44,8 @@ export interface TableProps<Data extends Record<string, any>> {
    */
   name?: string
   renderRowSubComponent?: (data: { row: Row<Data> }) => ReactNode
+  autoResetSortBy?: boolean
+  autoResetPage?: boolean
 }
 
 export const TableV2 = <Data extends Record<string, any>>(props: TableProps<Data>): React.ReactElement => {
@@ -58,7 +60,9 @@ export const TableV2 = <Data extends Record<string, any>>(props: TableProps<Data
     rowDataTestID,
     getRowClassName,
     name,
-    renderRowSubComponent
+    renderRowSubComponent,
+    autoResetSortBy = true,
+    autoResetPage = true
   } = props
 
   const { headerGroups, page, prepareRow } = useTable(
@@ -67,7 +71,9 @@ export const TableV2 = <Data extends Record<string, any>>(props: TableProps<Data
       data,
       initialState: { pageIndex: defaultTo(pagination?.pageIndex, 0) },
       manualPagination: true,
-      pageCount: defaultTo(pagination?.pageCount, -1)
+      pageCount: defaultTo(pagination?.pageCount, -1),
+      autoResetSortBy: autoResetSortBy,
+      autoResetPage: autoResetPage
     },
     useSortBy,
     useExpanded,


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
