### PR TITLE
feat: Add StringSubstitute component

### DIFF
--- a/packages/uicore/src/components/StringSubstitute/StringSubstitute.tsx
+++ b/packages/uicore/src/components/StringSubstitute/StringSubstitute.tsx
@@ -1,0 +1,66 @@
+import React, { Fragment } from 'react'
+
+type SubstituteVars = Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+
+function translateExpression(str: string, key: string, vars: SubstituteVars) {
+  // Replace simple i18n expression {key|match1:value1,match2:value2}
+  // Sample: '{user} wants to merge {number} {number|1:commit,commits} into {target} from {source}'
+  // Find `{number|`
+  const startIndex = str.indexOf(`{${key}|`)
+  const MATCH_ELSE_KEY = '___'
+
+  if (startIndex !== -1) {
+    // Find closing `}`
+    const endIndex = str.indexOf('}', startIndex)
+
+    if (endIndex !== -1) {
+      // Get whole expression of `{number|1:commit,commits}`
+      const expression = str.substring(startIndex, endIndex + 1)
+
+      // Build value mapping from expression
+      const mapping = expression
+        .split('|')[1] // Get `1:commit,commits}`
+        .slice(0, -1) // Remove last closing `}`
+        .split(',') // ['1:commit', 'commits']
+        .reduce((map, token) => {
+          // Convert to a map { 1: commit, [MATCH_ELSE_KEY]: commits }
+          const [k, v] = token.split(':')
+          map[v ? k : MATCH_ELSE_KEY] = v || k
+          return map
+        }, {} as Record<string, string>)
+
+      const matchedValue = mapping[vars[key]] || mapping[MATCH_ELSE_KEY]
+
+      if (matchedValue) {
+        return str.replace(expression, matchedValue)
+      }
+    }
+  }
+
+  return str
+}
+
+export const StringSubstitute: React.FC<{
+  str: string
+  vars: SubstituteVars
+}> = ({ str, vars }) => {
+  const re = Object.keys(vars)
+    .map(key => {
+      str = translateExpression(str, key, vars)
+      return `{${key}}`
+    })
+    .join('|')
+
+  return (
+    <>
+      {str
+        .split(new RegExp('(' + re + ')', 'gi'))
+        .filter(token => !!(token || '').trim())
+        .map((token, index) => (
+          <Fragment key={index}>
+            {token.startsWith('{') && token.endsWith('}') ? vars[token.substring(1, token.length - 1)] || token : token}
+          </Fragment>
+        ))}
+    </>
+  )
+}

--- a/packages/uicore/src/index.ts
+++ b/packages/uicore/src/index.ts
@@ -243,5 +243,6 @@ export {
   MultiStepProgressIndicator,
   MultiStepProgressIndicatorProps
 } from './components/MultiStepProgressIndicator/MultiStepProgressIndicator'
+export { StringSubstitute } from './components/StringSubstitute/StringSubstitute'
 export * from '@harness/design-system'
 export * from '@harness/icons'


### PR DESCRIPTION
This component substitutes an i18n string with values as React components.

**Example**
```tsx
// strings.en.yaml
metaLine: '{user} wants to merge {number} {number|1:commit,commits} into {target} from {source}'

const vars = {
    user: <strong>{createdBy}</strong>,
    number: 1, 
    target: <GitRefLink text={targetBranch} />,
    source: <GitRefLink text={sourceBranch} />
  }

<StringSubstitute str={getString('pr.metaLine')} vars={vars} />
```

**Output:**
<img width="620" alt="Screen Shot 2022-12-02 at 2 53 03 PM" src="https://user-images.githubusercontent.com/29714664/205403025-52be9293-0971-4970-8660-410c1d2f5977.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
