### PR TITLE
feat: [PL-30311]: Avatar component—added null checks on both name & email 

### DIFF
--- a/packages/uicore/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.stories.tsx
@@ -75,7 +75,7 @@ export const Image: Story<AvatarProps> = args => (
   </Layout.Horizontal>
 )
 
-// Edge case for testing, this should not render anything
+// Edge case for testing, this should render user icon without any initials
 export const NullName: Story<AvatarProps> = args => (
   <Layout.Horizontal spacing="small" id="primary-buttons">
     <Avatar name={null as any} {...args} />

--- a/packages/uicore/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.stories.tsx
@@ -74,3 +74,10 @@ export const Image: Story<AvatarProps> = args => (
     />
   </Layout.Horizontal>
 )
+
+// Edge case for testing, this should not render anything
+export const NullName: Story<AvatarProps> = args => (
+  <Layout.Horizontal spacing="small" id="primary-buttons">
+    <Avatar name={null as any} {...args} />
+  </Layout.Horizontal>
+)

--- a/packages/uicore/src/components/Avatar/Avatar.test.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.test.tsx
@@ -31,10 +31,20 @@ describe('Render basic component', () => {
     expect(getInitialsFromNameOrEmail('All Name Here')).toEqual('AH')
     expect(getInitialsFromNameOrEmail('All Name')).toEqual('AN')
     expect(getInitialsFromNameOrEmail('AllNameHere')).toEqual('A')
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(getInitialsFromNameOrEmail('AllNameHere', null)).toEqual('A')
   })
   test('getInitials with email', () => {
     expect(getInitialsFromNameOrEmail('', 'AllNameHere@com')).toEqual('A')
     expect(getInitialsFromNameOrEmail('', 'AllName.here@com')).toEqual('Ah')
+    expect(getInitialsFromNameOrEmail(undefined, 'abc')).toEqual('a')
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(getInitialsFromNameOrEmail(null, 'abc')).toEqual('a')
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(getInitialsFromNameOrEmail(null, null)).toEqual(undefined)
   })
   test('getSumofCharacters', () => {
     expect(getSumOfAllCharacters('abcd')).toEqual(10)

--- a/packages/uicore/src/components/Avatar/Avatar.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.tsx
@@ -107,6 +107,7 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
   const fontSize = sizes[size].fontSize
   const lineHeight = sizes[size].lineHeight
   const imageHeightWidth = sizes[size].imageHeight
+  let forcePreventHover = false
   let inner
   let initials = ''
   if (!src) {
@@ -143,10 +144,12 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
     )
   } else {
     if (!initials) {
-      return null
+      // show empty user Icon if neither 'src', nor 'initials' are truthy
+      inner = <Icon name="user" color={Color.WHITE} />
+      forcePreventHover = true
+    } else {
+      inner = initials.toUpperCase()
     }
-    inner = initials
-    inner = inner.toUpperCase()
   }
   const toolTipStyle = {
     ...contentStyle,
@@ -228,6 +231,7 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
       return contentStyle
     }
   }
+  const isHoverDisabled = !hoverCard || forcePreventHover
   return (
     <div className={classnames(className, css.Avatar, css.contentStyle)} style={style} onClick={onClick} {...rest}>
       <Popover
@@ -236,7 +240,7 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
         usePortal={false}
         className={css.avatarPopOver}
         position="top"
-        disabled={!hoverCard}>
+        disabled={isHoverDisabled}>
         <div className={css.AvatarInner} style={getUpdatedContentStyle()}>
           {inner}
         </div>

--- a/packages/uicore/src/components/Avatar/Avatar.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.tsx
@@ -145,7 +145,7 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
   } else {
     if (!initials) {
       // show empty user Icon if neither 'src', nor 'initials' are truthy
-      const iconSize = parseInt(sizes?.[size].fontSize, 10) as IconProps['size']
+      const iconSize = parseInt(sizes[size].fontSize, 10) as IconProps['size']
       inner = <Icon name="user" color={Color.WHITE} size={iconSize} />
       forcePreventHover = true
     } else {

--- a/packages/uicore/src/components/Avatar/Avatar.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.tsx
@@ -145,7 +145,8 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
   } else {
     if (!initials) {
       // show empty user Icon if neither 'src', nor 'initials' are truthy
-      inner = <Icon name="user" color={Color.WHITE} />
+      const iconSize = parseInt(sizes?.[size].fontSize, 10) as IconProps['size']
+      inner = <Icon name="user" color={Color.WHITE} size={iconSize} />
       forcePreventHover = true
     } else {
       inner = initials.toUpperCase()

--- a/packages/uicore/src/components/Avatar/Avatar.tsx
+++ b/packages/uicore/src/components/Avatar/Avatar.tsx
@@ -101,6 +101,7 @@ export const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
     hoverCardDetailsCallBack,
     ...rest
   } = props
+
   let textColor = color
   const formatedSize = sizes[size].size
   const fontSize = sizes[size].fontSize

--- a/packages/uicore/src/components/Avatar/utils.ts
+++ b/packages/uicore/src/components/Avatar/utils.ts
@@ -5,24 +5,29 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import { pick } from 'lodash-es'
+import { pick, defaultTo } from 'lodash-es'
 import { Color } from '@harness/design-system'
-export const getInitialsFromNameOrEmail = (name = '', email = ''): string => {
-  let initialsFromName = name
-    .split(/-| /)
-    .map((n: string) => n[0])
-    .join('')
 
+export const getInitialsFromNameOrEmail = (name = '', email = ''): string => {
+  let initialsFromName = defaultTo(
+    name
+      ?.split(/-| /)
+      .map((n: string) => n[0])
+      .join(''),
+    ''
+  )
   initialsFromName =
     initialsFromName.length > 2
       ? `${initialsFromName[0]}${initialsFromName[initialsFromName.length - 1]}`
       : initialsFromName
-  let initialsFromEmail = email.split('@')[0]
+
+  let initialsFromEmail = defaultTo(email?.split('@')[0], '')
   const splitedInitialsFromEmail = initialsFromEmail.split('.')
   initialsFromEmail =
     splitedInitialsFromEmail.length > 1
       ? `${splitedInitialsFromEmail[0][0]}${splitedInitialsFromEmail[splitedInitialsFromEmail.length - 1][0]}`
       : initialsFromEmail[0]
+
   return initialsFromName || initialsFromEmail
 }
 
@@ -36,6 +41,7 @@ export const getSumOfAllCharacters = (str: string): number => {
         }, 0)
     : 0
 }
+
 export const defaultAvatarColor = Object.values(
   pick(Color, [
     'GREY_600',

--- a/packages/uicore/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/uicore/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -180,6 +180,42 @@ exports[`Render basic component should check snapshot with Avatar props without 
               style="border-radius: 100%; line-height: 26px; width: 32px; height: 32px; font-size: 10px;"
               tabindex="0"
             >
+              <span
+                class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-white"
+                data-icon="user"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  viewBox="0 0 61 73"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M18.001 17.512c0-6.732 5.458-12.19 12.19-12.19 6.732 0 12.19 5.458 12.19 12.19 0 6.732-5.458 12.19-12.19 12.19-6.732 0-12.19-5.458-12.19-12.19zM30.191.522c-9.383 0-16.99 7.607-16.99 16.99 0 5.651 2.76 10.659 7.005 13.747L.466 68.8a2.4 2.4 0 002.123 3.517h55.206a2.4 2.4 0 002.105-3.552L39.608 31.656c4.565-3.046 7.573-8.244 7.573-14.144 0-9.383-7.607-16.99-16.99-16.99zm-5.744 32.984a16.96 16.96 0 005.744.996c1.77 0 3.476-.27 5.08-.773l18.476 33.787H6.563l17.884-34.01z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="stackAvatar Avatar contentStyle"
+      >
+        <span
+          class="bp3-popover-wrapper avatarPopOver"
+        >
+          <span
+            class="bp3-popover-target"
+          >
+            <div
+              class="AvatarInner"
+              style="border-radius: 100%; line-height: 26px; width: 32px; height: 32px; font-size: 10px;"
+              tabindex="0"
+            >
               GH
             </div>
           </span>
@@ -328,6 +364,42 @@ exports[`Render basic component should check snapshot with Avatar props without 
               tabindex="0"
             >
               GH
+            </div>
+          </span>
+        </span>
+      </div>
+      <div
+        class="Avatar contentStyle"
+      >
+        <span
+          class="bp3-popover-wrapper avatarPopOver"
+        >
+          <span
+            class="bp3-popover-target"
+          >
+            <div
+              class="AvatarInner"
+              style="border-radius: 100%; line-height: 26px; width: 32px; height: 32px; font-size: 10px;"
+              tabindex="0"
+            >
+              <span
+                class="bp3-icon StyledProps--main StyledProps--color StyledProps--color-white"
+                data-icon="user"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  viewBox="0 0 61 73"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M18.001 17.512c0-6.732 5.458-12.19 12.19-12.19 6.732 0 12.19 5.458 12.19 12.19 0 6.732-5.458 12.19-12.19 12.19-6.732 0-12.19-5.458-12.19-12.19zM30.191.522c-9.383 0-16.99 7.607-16.99 16.99 0 5.651 2.76 10.659 7.005 13.747L.466 68.8a2.4 2.4 0 002.123 3.517h55.206a2.4 2.4 0 002.105-3.552L39.608 31.656c4.565-3.046 7.573-8.244 7.573-14.144 0-9.383-7.607-16.99-16.99-16.99zm-5.744 32.984a16.96 16.96 0 005.744.996c1.77 0 3.476-.27 5.08-.773l18.476 33.787H6.563l17.884-34.01z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
             </div>
           </span>
         </span>

--- a/packages/uicore/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/uicore/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -186,9 +186,9 @@ exports[`Render basic component should check snapshot with Avatar props without 
               >
                 <svg
                   fill="currentColor"
-                  height="16"
+                  height="10"
                   viewBox="0 0 61 73"
-                  width="16"
+                  width="10"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -388,9 +388,9 @@ exports[`Render basic component should check snapshot with Avatar props without 
               >
                 <svg
                   fill="currentColor"
-                  height="16"
+                  height="10"
                   viewBox="0 0 61 73"
-                  width="16"
+                  width="10"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/PL-30311

ES6+ treats `null` and `undefined` differently in case you provide a default value to a function. 
The default value for `name` (empty string) was not being picked up in case name was provided as null. Fixed it by adding null checks and `defaultTo`.

### Screenshots:
**No Name, email or src**
<img width="401" alt="image" src="https://user-images.githubusercontent.com/96057095/208062981-e4cde61c-bae5-4a28-9af7-1a65e8cb43fc.png">


**How it looks in Avatar Group**
Before
<img width="207" alt="image" src="https://user-images.githubusercontent.com/96057095/208042811-4a2a2bf7-5976-4e10-837f-89437740057c.png">

After (different sizes)
<img width="595" alt="image" src="https://user-images.githubusercontent.com/96057095/208062482-3ec9c551-2dc1-4505-bbc8-03d20069ce2e.png">
<img width="440" alt="image" src="https://user-images.githubusercontent.com/96057095/208062689-f8bb567d-46dd-4010-82fa-a7ff5ced2e2f.png">
<img width="423" alt="image" src="https://user-images.githubusercontent.com/96057095/208062734-5616c711-eb66-4616-8b5f-3da6b97f9495.png">
<img width="675" alt="image" src="https://user-images.githubusercontent.com/96057095/208062768-22e3faaf-c2b1-49a3-a974-56a0423a5895.png">
<img width="567" alt="image" src="https://user-images.githubusercontent.com/96057095/208062825-e8c06295-adaa-48cb-b0a7-7d46e84b273b.png">




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
