### PR TITLE
fix: [CDS-47282]: fixed render view of label as ReactElement for ThumbnailSelect component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.98.0",
+  "version": "3.98.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Thumbnail/Thumbnail.tsx
+++ b/packages/uicore/src/components/Thumbnail/Thumbnail.tsx
@@ -73,7 +73,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = props => {
         className={css.squareCard}>
         {cardContent}
       </Card>
-      {(icon || imageProps?.src) && !isValidElement(label) && (
+      {(icon || imageProps?.src) && label && !isValidElement(label) && (
         <Text
           className={css.label}
           font={{ weight: 'semi-bold' }}

--- a/packages/uicore/src/components/Thumbnail/Thumbnail.tsx
+++ b/packages/uicore/src/components/Thumbnail/Thumbnail.tsx
@@ -51,7 +51,9 @@ export const Thumbnail: React.FC<ThumbnailProps> = props => {
     }
 
     if (label) {
-      return (
+      return isValidElement(label) ? (
+        label
+      ) : (
         <Text className={css.label} color={Color.BLACK}>
           {label}
         </Text>
@@ -71,18 +73,15 @@ export const Thumbnail: React.FC<ThumbnailProps> = props => {
         className={css.squareCard}>
         {cardContent}
       </Card>
-      {isValidElement(label)
-        ? label
-        : (icon || imageProps?.src) &&
-          label && (
-            <Text
-              className={css.label}
-              font={{ weight: 'semi-bold' }}
-              color={disabled ? Color.GREY_500 : Color.GREY_600}
-              margin={{ top: 'small' }}>
-              {label}
-            </Text>
-          )}
+      {(icon || imageProps?.src) && !isValidElement(label) && (
+        <Text
+          className={css.label}
+          font={{ weight: 'semi-bold' }}
+          color={disabled ? Color.GREY_500 : Color.GREY_600}
+          margin={{ top: 'small' }}>
+          {label}
+        </Text>
+      )}
       <input type="checkbox" name={name} value={value} onChange={onClick} checked={selected} disabled={disabled} />
     </label>
   )

--- a/packages/uicore/src/components/Thumbnail/Thumbnail.tsx
+++ b/packages/uicore/src/components/Thumbnail/Thumbnail.tsx
@@ -17,6 +17,7 @@ import { Color } from '@harness/design-system'
 export interface ThumbnailProps {
   name?: string
   label?: string | React.ReactElement
+  /** Don't pass icon or imageProps.src to render label as a React Element */
   value?: string
   icon?: IconName
   /** renders image instead of icon when imageProps.src is passed */


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
