### PR TITLE
feat: [PIE-6791]: retain value when switching from fixed to expression type

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.97.0",
+  "version": "3.98.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/__tests__/FormikForm.test.tsx
+++ b/packages/uicore/src/components/FormikForm/__tests__/FormikForm.test.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import { act, findByText, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { Formik, FormikForm, FormInput } from '../FormikForm'
 import { Button } from '../../Button/Button'
-import { MultiTypeInputType } from 'components/MultiTypeInput/MultiTypeInputUtils'
+import { MultiTypeInputType, MultiTypeInputValue } from 'components/MultiTypeInput/MultiTypeInputUtils'
 import { TooltipContextProvider } from '../../../frameworks/Tooltip/TooltipContext'
 import userEvent from '@testing-library/user-event'
 
@@ -437,5 +437,37 @@ describe('Test basic Components', () => {
 
     // tag2 should only be seen once as saved in the snapshot
     expect(container).toMatchSnapshot()
+  })
+
+  test('switching to expression from fixed type should not clear the value', async () => {
+    const onChange = jest.fn()
+    render(
+      renderFormikForm(
+        <FormInput.MultiTextInput
+          name="multiTextInputName"
+          label="Multi Text Input"
+          placeholder="enter text"
+          onChange={onChange}
+          multiTextInputProps={{}}
+        />
+      )
+    )
+
+    const input = screen.getByPlaceholderText('enter text')
+    userEvent.clear(input)
+    userEvent.type(input, 'value')
+    expect(input).toHaveDisplayValue('value')
+
+    const multiTypeButton = screen.getByTestId('multi-type-button')
+    expect(multiTypeButton).toBeInTheDocument()
+    userEvent.click(multiTypeButton as HTMLButtonElement)
+
+    const expressionOption = await screen.findByText(/expression/i)
+    userEvent.click(expressionOption)
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith('value', MultiTypeInputValue.STRING, MultiTypeInputType.EXPRESSION)
+    })
+    expect(input).toHaveDisplayValue('value')
   })
 })

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -115,24 +115,36 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
   const [type, setType] = useState<MultiTypeInputType>(getMultiTypeFromValue(value))
   const [mentionsType] = useState(`multi-type-input-${Utils.randomId()}`)
   const switchType = (newType: MultiTypeInputType) => {
-    if (type !== newType) {
-      setType(newType)
-      onTypeChange?.(newType)
-      let _inputValue
-
-      switch (newType) {
-        case MultiTypeInputType.RUNTIME:
-          _inputValue = RUNTIME_INPUT_VALUE
-          break
-        case MultiTypeInputType.EXECUTION_TIME:
-          _inputValue = EXECUTION_TIME_INPUT_VALUE
-          break
-        default:
-          _inputValue = defaultValueToReset
-      }
-
-      onChange?.(_inputValue, MultiTypeInputValue.STRING, newType)
+    if (type === newType) {
+      return
     }
+
+    setType(newType)
+    onTypeChange?.(newType)
+
+    let _inputValue
+
+    switch (newType) {
+      case MultiTypeInputType.RUNTIME:
+        _inputValue = RUNTIME_INPUT_VALUE
+        break
+      case MultiTypeInputType.EXECUTION_TIME:
+        _inputValue = EXECUTION_TIME_INPUT_VALUE
+        break
+      case MultiTypeInputType.EXPRESSION: {
+        // retain value if switching from fixed to expression type
+        if (type === MultiTypeInputType.FIXED && typeof value === 'string') {
+          _inputValue = value
+        } else {
+          _inputValue = defaultValueToReset
+        }
+        break
+      }
+      default:
+        _inputValue = defaultValueToReset
+    }
+
+    onChange?.(_inputValue, MultiTypeInputValue.STRING, newType)
   }
 
   const FixedTypeComponent = fixedTypeComponent
@@ -227,7 +239,8 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
             popoverClassName: css.popover,
             className: css.wrapper,
             lazy: true
-          }}>
+          }}
+          data-testid="multi-type-button">
           <Icon name={MultiTypeIcon[type]} size={MultiTypeIconSize[type]} />
         </Button>
       )}


### PR DESCRIPTION
This updates the `ExpressionAndRuntimeType` component to prevent clearing the value when the type is switched from fixed to expression. The value is cleared in all other cases.


https://user-images.githubusercontent.com/52284933/207789194-0f093257-c4c8-4927-9ff3-5aa7183f761f.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
