### PR TITLE
feat: [PL-29962]: fix word-wrap issue 

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.99.1",
+  "version": "3.99.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -92,7 +92,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
         color={Color.BLACK}
         margin={{ top: 'large', bottom: 'xxlarge' }}
         className={css.body}>
-        {contentText}
+        <Text lineClamp={5}>{contentText}</Text>
       </Layout.Vertical>
       {children}
       <Layout.Horizontal spacing="small">


### PR DESCRIPTION
Fix word Wrap issue in Confirmation Dialog using `<Text/>` component and lineClamp


### Screenshots

BEFORE:
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/96057095/208614317-fb603668-005d-4c78-ad2a-4d566f7d6e50.png">


AFTER:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/96057095/208614158-8df1701c-5909-4171-9149-78d013daafa0.png">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
