### PR TITLE
feat: PIE-7367: extend UICore dropdown to allow for lazy loading of items

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.99.3",
+  "version": "3.99.4",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/DropDown/DropDown.stories.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.stories.tsx
@@ -76,7 +76,7 @@ Basic.args = {
   items: staticItems
 }
 
-export const PromiseBased: Story<DropDownProps> = args => {
+export const AsyncItems: Story<DropDownProps> = args => {
   const [query, setQuery] = useState('')
   return (
     <Layout.Horizontal flex>
@@ -93,11 +93,39 @@ export const PromiseBased: Story<DropDownProps> = args => {
   )
 }
 
-PromiseBased.args = {
+AsyncItems.args = {
   placeholder: 'Status',
   items: (): Promise<SelectOption[]> => {
     return new Promise<SelectOption[]>(resolve => {
-      setTimeout(() => resolve(staticItems), 3000)
+      setTimeout(() => resolve(staticItems), 2000)
     })
-  }
+  },
+  isLazyItemsQuery: false
+}
+
+export const AsyncItemsLazy: Story<DropDownProps> = args => {
+  const [query, setQuery] = useState('')
+  return (
+    <Layout.Horizontal flex>
+      <DropDown
+        {...args}
+        onChange={option => {
+          // eslint-disable-next-line no-alert
+          alert(option.value)
+        }}
+        onQueryChange={setQuery}
+        query={query}
+      />
+    </Layout.Horizontal>
+  )
+}
+
+AsyncItemsLazy.args = {
+  placeholder: 'Choose filter',
+  items: (): Promise<SelectOption[]> => {
+    return new Promise<SelectOption[]>(resolve => {
+      setTimeout(() => resolve(staticItems), 2000)
+    })
+  },
+  isLazyItemsQuery: true
 }

--- a/packages/uicore/src/components/DropDown/DropDown.stories.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.stories.tsx
@@ -100,7 +100,7 @@ AsyncItems.args = {
       setTimeout(() => resolve(staticItems), 2000)
     })
   },
-  isLazyItemsQuery: false
+  lazyItems: false
 }
 
 export const AsyncItemsLazy: Story<DropDownProps> = args => {
@@ -127,5 +127,5 @@ AsyncItemsLazy.args = {
       setTimeout(() => resolve(staticItems), 2000)
     })
   },
-  isLazyItemsQuery: true
+  lazyItems: true
 }

--- a/packages/uicore/src/components/DropDown/DropDown.stories.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.stories.tsx
@@ -99,33 +99,34 @@ AsyncItems.args = {
     return new Promise<SelectOption[]>(resolve => {
       setTimeout(() => resolve(staticItems), 2000)
     })
-  },
-  lazyItems: false
+  }
 }
 
-export const AsyncItemsLazy: Story<DropDownProps> = args => {
+export const AsyncItemsLazy: Story<DropDownProps> = () => {
   const [query, setQuery] = useState('')
+  const [items, setItems] = useState<SelectOption[] | undefined>()
+
+  const getLazyItems = async () => {
+    return new Promise<void>(resolve => {
+      setTimeout(() => {
+        resolve()
+        setItems(staticItems)
+      }, 2000)
+    })
+  }
   return (
     <Layout.Horizontal flex>
       <DropDown
-        {...args}
+        placeholder="Choose filter"
         onChange={option => {
           // eslint-disable-next-line no-alert
           alert(option.value)
         }}
         onQueryChange={setQuery}
         query={query}
+        items={items}
+        getLazyItems={getLazyItems}
       />
     </Layout.Horizontal>
   )
-}
-
-AsyncItemsLazy.args = {
-  placeholder: 'Choose filter',
-  items: (): Promise<SelectOption[]> => {
-    return new Promise<SelectOption[]>(resolve => {
-      setTimeout(() => resolve(staticItems), 2000)
-    })
-  },
-  lazyItems: true
 }

--- a/packages/uicore/src/components/DropDown/DropDown.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.tsx
@@ -120,24 +120,13 @@ export const DropDown: FC<DropDownProps> = props => {
   useEffect(() => {
     if (Array.isArray(items)) {
       setDropDownItems(items)
-    } else if (typeof items === 'function' && !loading && !isLazyItemsQuery) {
+    } else if (typeof items === 'function') {
       // Do not enter this block if already loading
       if (loading) return
-      setLoading(true)
-      Promise.resolve(items())
-        .then(itemsResponse => {
-          setDropDownItems(itemsResponse)
-        })
-        .finally(() => {
-          setLoading(false)
-        })
-    }
-  }, [JSON.stringify(items)])
+      // For lazy loaded queries call the items function once
+      // defer the call until the dropdown is opened or there's already a previously selected item
+      if (isLazyItemsQuery && !(isDropdownOpenedOnce || value)) return
 
-  useEffect(() => {
-    // For lazy loaded queries call the items function once
-    // defer the call until the dropdown is opened or there's already a previously selected item
-    if (isLazyItemsQuery && (isDropdownOpenedOnce || !!value) && typeof items === 'function') {
       setLoading(true)
       Promise.resolve(items())
         .then(itemsResponse => {


### PR DESCRIPTION
![Kapture 2023-01-03 at 12 24 07](https://user-images.githubusercontent.com/20707504/210311861-6107dfa0-054b-494e-b08d-35bfe15b7314.gif)

- dropdown takes a promise function to get the list of items but that's called immediately on mount and disable the field if no items are found

- `getLazyItems` provides an option to defer the call until the dropdown is opened. This will be called on the dropdown open and this function is responsible for fetch and update of the items

- This goes well with refetch + data combination of queries and even when multiple parents need the same data Ex: (Dropdown + some other component) need the same data from query
