### PR TITLE
feat: [PL-30656]: autofocus search input across the board

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.99.4",
+  "version": "3.95.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.95.0",
+  "version": "3.100.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ExpandingSearchInput/ExpandingSearchInput.tsx
+++ b/packages/uicore/src/components/ExpandingSearchInput/ExpandingSearchInput.tsx
@@ -59,7 +59,7 @@ export function ExpandingSearchInput(
     onEnter,
     onPrev: propsOnPrev,
     onNext: propsOnNext,
-    autoFocus,
+    autoFocus = true,
     className = '',
     throttle = DEFAULT_THROTTLE,
     showPrevNextButtons,


### PR DESCRIPTION
`ExpandingSearchInput` will now autofocus by default unless overriden to be false.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
