### PR TITLE
feat: [PL-30704]: Avatar overlap issue fix

### DIFF
--- a/packages/uicore/src/components/Avatar/Avatar.css
+++ b/packages/uicore/src/components/Avatar/Avatar.css
@@ -8,6 +8,7 @@
 .Avatar {
   display: inline-block;
   margin: 0 5px;
+  position: relative;
 }
 
 .AvatarInner {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

Issue - This issue is happening only in chrome. Default stacking behaviour of position static elements is changed in the latest version. 


Before

<img width="582" alt="Screenshot 2023-01-05 at 7 03 03 PM" src="https://user-images.githubusercontent.com/62028553/210792302-6cb879f6-c3a9-46af-a095-669ee6caca57.png">

After
<img width="653" alt="Screenshot 2023-01-05 at 7 03 30 PM" src="https://user-images.githubusercontent.com/62028553/210792145-8024e975-1028-401c-82fc-fd307048ba62.png">


- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
