### PR TITLE
fix: [PL-30827]: remove table sortable prop

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.101.0",
+  "version": "3.102.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TableV2/TableV2.css
+++ b/packages/uicore/src/components/TableV2/TableV2.css
@@ -79,7 +79,7 @@
 
   [role='columnheader'].resizable {
     margin: 0;
-    padding: 0.5rem;
+    margin-right: 0.5rem;
     &:hover {
       border-right: 1px solid var(--grey-200);
     }

--- a/packages/uicore/src/components/TableV2/TableV2.stories.tsx
+++ b/packages/uicore/src/components/TableV2/TableV2.stories.tsx
@@ -18,7 +18,7 @@ export default {
 } as Meta
 
 export const Basic: ComponentStory<typeof TableV2> = args => {
-  return <TableV2 {...args} sortable={true} onRowClick={noop} />
+  return <TableV2 {...args} onRowClick={noop} />
 }
 Basic.args = {
   data: [
@@ -39,6 +39,8 @@ Basic.args = {
       age: 25
     }
   ],
+  sortable: true,
+  resizable: false,
   pagination: {
     itemCount: 100,
     pageCount: 10,

--- a/packages/uicore/src/components/TableV2/TableV2.stories.tsx
+++ b/packages/uicore/src/components/TableV2/TableV2.stories.tsx
@@ -39,7 +39,6 @@ Basic.args = {
       age: 25
     }
   ],
-  sortable: true,
   resizable: false,
   pagination: {
     itemCount: 100,
@@ -57,7 +56,8 @@ Basic.args = {
     {
       Header: 'Age',
       accessor: row => row.age,
-      id: 'age'
+      id: 'age',
+      disableSortBy: true
     }
   ]
 }
@@ -72,7 +72,7 @@ export const Expandable: ComponentStory<typeof TableV2> = args => {
     []
   )
 
-  return <TableV2 {...args} sortable={true} renderRowSubComponent={renderRowSubComponent} />
+  return <TableV2 {...args} renderRowSubComponent={renderRowSubComponent} />
 }
 Expandable.args = {
   columns: [

--- a/packages/uicore/src/components/TableV2/TableV2.tsx
+++ b/packages/uicore/src/components/TableV2/TableV2.tsx
@@ -6,7 +6,17 @@
  */
 
 import React, { ReactNode } from 'react'
-import { useTable, Column, Row, useSortBy, usePagination, useResizeColumns, useExpanded } from 'react-table'
+import {
+  useTable,
+  Column,
+  Row,
+  useSortBy,
+  usePagination,
+  useResizeColumns,
+  useExpanded,
+  UseSortByColumnOptions,
+  UseResizeColumnsOptions
+} from 'react-table'
 import cx from 'classnames'
 import { defaultTo } from 'lodash-es'
 import type { IconName } from '@blueprintjs/icons'
@@ -20,7 +30,7 @@ export interface TableProps<Data extends Record<string, any>> {
   /**
    * Column Configuration
    */
-  columns: Array<Column<Data>>
+  columns: Array<Column<Data> & UseSortByColumnOptions<Data> & UseResizeColumnsOptions<Data>>
   data: Data[]
   className?: string
   resizable?: boolean

--- a/packages/uicore/src/components/TableV2/TableV2.tsx
+++ b/packages/uicore/src/components/TableV2/TableV2.tsx
@@ -23,11 +23,6 @@ export interface TableProps<Data extends Record<string, any>> {
   columns: Array<Column<Data>>
   data: Data[]
   className?: string
-  /**
-   * Is the table sortable?
-   * @default true
-   */
-  sortable?: boolean
   resizable?: boolean
   hideHeaders?: boolean
   pagination?: PaginationProps
@@ -61,7 +56,6 @@ export const TableV2 = <Data extends Record<string, any>>(props: TableProps<Data
     columns,
     data,
     className,
-    sortable = false,
     resizable = false,
     hideHeaders = false,
     autoResetExpanded = true,
@@ -124,42 +118,41 @@ export const TableV2 = <Data extends Record<string, any>>(props: TableProps<Data
               <div
                 {...headerGroup.getHeaderGroupProps()}
                 className={cx(css.header, { [css.minimal]: !!props.minimal })}>
-                {headerGroup.headers.map(header => {
-                  const label = header.render('Header')
-                  const tooltipId = name ? name + header.id : undefined
-                  const serverSideSort = header?.serverSortProps?.enableServerSort
+                {headerGroup.headers.map(column => {
+                  const label = column.render('Header')
+                  const tooltipId = name ? name + column.id : undefined
+                  const serverSideSort = column?.serverSortProps?.enableServerSort
                     ? {
                         onClick: () => {
-                          header.serverSortProps?.getSortedColumn?.({ sort: header.id })
+                          column.serverSortProps?.getSortedColumn?.({ sort: column.id })
                         }
                       }
                     : {}
                   return (
                     // eslint-disable-next-line react/jsx-key
                     <div
-                      {...header.getHeaderProps(sortable ? header.getSortByToggleProps() : void 0)}
-                      {...header.getHeaderProps(resizable ? header.getHeaderProps() : void 0)}
-                      className={cx(css.cell, { [css.sortable]: sortable }, { [css.resizable]: resizable })}
-                      style={{ width: header.width }}
+                      {...column.getHeaderProps(column.getSortByToggleProps())}
+                      className={cx(css.cell, { [css.sortable]: column.canSort, [css.resizable]: resizable })}
+                      style={{ width: column.width }}
                       {...serverSideSort}>
                       <Text
                         font={{ variation: FontVariation.TABLE_HEADERS }}
                         tooltipProps={{ dataTooltipId: tooltipId }}>
                         {label}
                       </Text>
-                      {sortable && header.canSort ? (
+                      {column.canSort ? (
                         <Icon
                           name={getIconName({
-                            isSorted: header.isSorted,
-                            isSortedDesc: header.isSortedDesc,
-                            isServerSorted: header.serverSortProps?.isServerSorted,
-                            isServerSortedDesc: header.serverSortProps?.isServerSortedDesc
+                            isSorted: column.isSorted,
+                            isSortedDesc: column.isSortedDesc,
+                            isServerSorted: column.serverSortProps?.isServerSorted,
+                            isServerSortedDesc: column.serverSortProps?.isServerSortedDesc
                           })}
                           size={15}
                           padding={{ left: 'small' }}
                         />
                       ) : null}
-                      {resizable && <div {...header.getResizerProps()} className={css.resizer} />}
+                      {resizable && <div {...column.getResizerProps()} className={css.resizer} />}
                     </div>
                   )
                 })}


### PR DESCRIPTION
Changes:

1. Removes `sortable` prop from the table, since it's actually a column prop. This fixes the issue where pointer cursor was appearing on columns which were not sortable.
2. Fixes sort and resize css according to built-in props
3. Renames `header` to `column` in code, to match closer to the docs and examples
4. Fixes types for Column options

Note: This change enables sorting by default on all tables, unless disabled at column level.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
