### PR TITLE
fix: tooltip should come only on the main btn of split btn

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.102.0",
+  "version": "3.102.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/SplitButton/SplitButton.tsx
+++ b/packages/uicore/src/components/SplitButton/SplitButton.tsx
@@ -19,6 +19,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
   icon,
   children,
   className,
+  tooltip,
   tooltipProps,
   disabled,
   dropdownDisabled,
@@ -36,6 +37,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
     <div className={css.splitButton}>
       <Button
         {...commonProps}
+        tooltip={tooltip}
         disabled={disabled}
         onClick={handleClick}
         text={text}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
