### PR TITLE
feat: [PL-30690]: Increasing Name-id character limit to 128

### DIFF
--- a/packages/uicore/src/components/InputWithIdentifier/InputWithIdentifier.tsx
+++ b/packages/uicore/src/components/InputWithIdentifier/InputWithIdentifier.tsx
@@ -45,7 +45,7 @@ export interface InputWithIdentifierProps {
    */
   isIdentifierEditable?: boolean
   /**
-   * @default 63
+   * @default 128
    */
   maxInput?: number
   /**
@@ -74,7 +74,7 @@ export const InputWithIdentifier: React.FC<InputWithIdentifierProps> = props => 
     idName = 'identifier',
     inputGroupProps,
     isIdentifierEditable = true,
-    maxInput = 63,
+    maxInput = 128,
     useUnversialToolTipId = true
   } = props
   const [editable, setEditable] = useState(false)


### PR DESCRIPTION
As a part of [Epic](https://harness.atlassian.net/browse/PL-30087) : we need to increase Name-id character limit to 128. 
So, making this changes is required to unblock all resources onboarding for this change.

Known and discussed behaviour : Till any entity is adopted to support 128 chars limit, UI will allow 128 chars and user will be  notified from API response.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
