### PR TITLE
feat: [PL-30529]: Showing selected item in case the item is missing in the dropdown list

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.106.0",
+  "version": "3.106.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/DropDown/DropDown.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.tsx
@@ -115,14 +115,21 @@ export const DropDown: FC<DropDownProps> = props => {
     }
   }
 
-  const activeItem = useMemo(
-    () =>
-      dropDownItems.find(item => item.value === value?.toString()) || {
-        label: '',
-        value: ''
-      },
-    [value, dropDownItems]
-  )
+  const activeItem = useMemo(() => {
+    const selectedFromList = dropDownItems.find(item => item.value === value?.toString())
+    if (selectedFromList) {
+      return selectedFromList
+    }
+
+    if (value) {
+      return { value: value, label: value }
+    }
+
+    return {
+      label: '',
+      value: ''
+    }
+  }, [value, dropDownItems])
 
   useEffect(() => {
     if (Array.isArray(items)) {


### PR DESCRIPTION
Issue - Selected item gets reset when the list is refreshed based on the query. This happens when the selected item is not part of the dropdown list (after list gets reset on different query).

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
