### PR TITLE
fix: [PIE-7765]: dropdown race conditions in search due to debounce and parent state

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.102.3",
+  "version": "3.103.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/DropDown/DropDown.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.tsx
@@ -189,7 +189,6 @@ export const DropDown: FC<DropDownProps> = props => {
         leftElement: <Icon name={'thinner-search'} size={12} color={Color.GREY_500} />,
         placeholder: 'Search'
       }}
-      query={query}
       onQueryChange={debouncedQuery}
       popoverProps={{
         targetTagName: 'div',


### PR DESCRIPTION
fixes https://harness.atlassian.net/browse/PIE-7765
reverts https://github.com/harness/uicore/pull/841

The way the dropdown component API evolved, not able to fix it without removing this, else we need to update places where it's used