### PR TITLE
feat: [PL-30747]: update Dropdown, Pagination to take popoverProps

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.103.0",
+  "version": "3.104.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/DropDown/DropDown.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.tsx
@@ -24,10 +24,7 @@ const Select = BPSelect.ofType<SelectOption>()
 type Props = ISelectProps<SelectOption>
 
 export interface DropDownProps
-  extends Omit<
-    Props,
-    'popoverProps' | 'itemRenderer' | 'onItemSelect' | 'items' | 'activeItem' | 'onActiveItemChange' | 'inputProps'
-  > {
+  extends Omit<Props, 'itemRenderer' | 'onItemSelect' | 'items' | 'activeItem' | 'onActiveItemChange' | 'inputProps'> {
   itemRenderer?: Props['itemRenderer']
   onChange: Props['onItemSelect']
   value?: string | null
@@ -86,6 +83,7 @@ export const DropDown: FC<DropDownProps> = props => {
     itemRenderer,
     className = '',
     popoverClassName = '',
+    popoverProps,
     usePortal = false,
     filterable = true,
     placeholder = 'Select',
@@ -202,7 +200,8 @@ export const DropDown: FC<DropDownProps> = props => {
           if (isOpen) {
             handleLazyLoadItems()
           }
-        }
+        },
+        ...popoverProps
       }}
       {...rest}>
       <Layout.Horizontal

--- a/packages/uicore/src/components/Pagination/Pagination.tsx
+++ b/packages/uicore/src/components/Pagination/Pagination.tsx
@@ -15,7 +15,7 @@ import { Text } from '../Text/Text'
 import { Button, ButtonSize } from '../Button/Button'
 import { SelectOption } from '../Select/Select'
 import { FontVariation } from '@harness/design-system'
-import { DropDown } from '../DropDown/DropDown'
+import { DropDown, DropDownProps } from '../DropDown/DropDown'
 import useWindowWidth from '../../hooks/useWindowWidth'
 
 import css from './Pagination.css'
@@ -32,6 +32,7 @@ export interface PaginationProps {
   onPageSizeChange?: (newPageSize: number) => void
   breakAt?: number
   showPagination?: boolean
+  pageSizeDropdownProps?: DropDownProps
 }
 
 interface PageNumbersProps {
@@ -147,7 +148,8 @@ const Pagination: React.FC<PaginationProps> = props => {
     hidePageNumbers,
     className,
     breakAt,
-    showPagination
+    showPagination,
+    pageSizeDropdownProps
   } = props
   const currentWindowWidth = useWindowWidth()
 
@@ -221,6 +223,7 @@ const Pagination: React.FC<PaginationProps> = props => {
             filterable={false}
             width={60}
             className={css.pageSizeDropdown}
+            {...pageSizeDropdownProps}
           />
           <Text>per page</Text>
         </Layout.Horizontal>

--- a/packages/uicore/src/components/Pagination/Pagination.tsx
+++ b/packages/uicore/src/components/Pagination/Pagination.tsx
@@ -32,7 +32,7 @@ export interface PaginationProps {
   onPageSizeChange?: (newPageSize: number) => void
   breakAt?: number
   showPagination?: boolean
-  pageSizeDropdownProps?: DropDownProps
+  pageSizeDropdownProps?: Partial<DropDownProps>
 }
 
 interface PageNumbersProps {


### PR DESCRIPTION
Updated Dropdown component to enable `popoverProps` prop.
Added new prop `pageSizeDropdownProps` to Pagination to customize the page size dropdown.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
