### PR TITLE
feat: Add popoverProps into SplitButton for extra customization

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/icons",
-  "version": "1.101.1",
+  "version": "1.101.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/icons.umd.js",

--- a/packages/uicore/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/uicore/src/components/SplitButton/SplitButton.stories.tsx
@@ -6,6 +6,7 @@
  */
 
 /* eslint-disable no-alert */
+import { PopoverPosition } from '@blueprintjs/core'
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories, Title } from '@storybook/addon-docs/blocks'
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import { noop } from 'lodash-es'
@@ -51,7 +52,16 @@ export default {
 export const PrimarySplitButton: ComponentStory<typeof SplitButton> = args => {
   return (
     <Container>
-      <SplitButton text="Save" icon="upload-box" variation={ButtonVariation.PRIMARY} {...args}>
+      <SplitButton
+        text="Save"
+        icon="upload-box"
+        variation={ButtonVariation.PRIMARY}
+        popoverProps={{
+          interactionKind: 'click',
+          usePortal: true,
+          position: PopoverPosition.BOTTOM_RIGHT
+        }}
+        {...args}>
         <SplitButtonOption icon="search-template" text="Save as Template" onClick={noop} />
         <SplitButtonOption icon="refresh" text="Refresh" onClick={noop} />
       </SplitButton>

--- a/packages/uicore/src/components/SplitButton/SplitButton.tsx
+++ b/packages/uicore/src/components/SplitButton/SplitButton.tsx
@@ -7,11 +7,16 @@
 
 import { IMenuItemProps, Menu, MenuItem, Position } from '@blueprintjs/core'
 import cx from 'classnames'
+import { PopoverProps } from 'components/Popover/Popover'
 import React, { MouseEvent } from 'react'
 import { Button, ButtonProps, HarnessDocTooltip, Popover } from '../..'
 import css from './SplitButton.css'
 
-type SplitButtonProps = Omit<ButtonProps, 'rightIcon'> & { className?: string; dropdownDisabled?: boolean }
+type SplitButtonProps = Omit<ButtonProps, 'rightIcon'> & {
+  className?: string
+  dropdownDisabled?: boolean
+  popoverProps?: PopoverProps
+}
 
 export const SplitButton: React.FC<SplitButtonProps> = ({
   onClick,
@@ -23,6 +28,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
   tooltipProps,
   disabled,
   dropdownDisabled,
+  popoverProps,
   ...commonProps
 }) => {
   const [isOptionsOpen, setOptionsOpen] = React.useState(false)
@@ -55,7 +61,8 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
           usePortal={false}
           minimal={true}
           fill={false}
-          position={Position.BOTTOM_RIGHT}>
+          position={Position.BOTTOM_RIGHT}
+          {...popoverProps}>
           <Button
             disabled={dropdownDisabled}
             rightIcon="chevron-down"


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
