### PR TITLE
feat: [CDS-49922]: add exact and strict optional props for nav links

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.108.1",
+  "version": "3.109.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TabNavigation/TabNavigation.tsx
+++ b/packages/uicore/src/components/TabNavigation/TabNavigation.tsx
@@ -16,6 +16,8 @@ interface NavigationLink {
   label: string
   to: string
   disabled?: boolean
+  strict?: boolean
+  exact?: boolean
 }
 
 export interface TabNavigationProps {
@@ -36,6 +38,8 @@ export const TabNavigation: React.FC<TabNavigationProps> = props => {
           })}
           activeClassName={css.active}
           to={link.to}
+          exact={link.exact}
+          strict={link.strict}
           onClick={e => link.disabled && e.preventDefault()}>
           {link.label}
         </NavLink>


### PR DESCRIPTION

```Added exact and strict optional props for navlinks```


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
