### PR TITLE
fix: [CDS-53063]: expression selection upon entering should not submit the form

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.110.0",
+  "version": "3.110.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
+++ b/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
@@ -250,6 +250,7 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
       const { key } = e
 
       if (key === 'Enter') {
+        e.stopPropagation()
         e.preventDefault()
       } else if ((key === 'ArrowUp' || key === 'ArrowDown') && activeItem) {
         let index = filteredItems.indexOf(activeItem)


### PR DESCRIPTION
- Fixes Run/Rerun Pipeline - When setting the runtime field to Expression and hitting Enter on the auto-complete option, pipeline execution will kick off immediately
- Stopped event propagation to prevent event bubbling

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
