### PR TITLE
fix: [PL-31466]: escape key close, outside click close - ModalDialog

### DIFF
--- a/jest/setup-file.js
+++ b/jest/setup-file.js
@@ -17,3 +17,9 @@ global.document.createRange = () => ({
 })
 
 global.window.scrollTo = jest.fn()
+
+global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}))

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.110.1",
+  "version": "3.110.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -55,6 +55,7 @@
   right: 22px;
   top: 22px;
   cursor: pointer;
+  z-index: 10;
 }
 
 .body {
@@ -74,6 +75,8 @@
 }
 
 .body .bodyContent {
+  position: relative;
+  z-index: 1;
   overflow: auto;
   height: 100%;
   padding: 0 var(--spacing-huge);

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -54,7 +54,6 @@ export interface ModalDialogProps extends IDialogProps {
 }
 
 export const ModalDialog: FC<ModalDialogProps> = ({
-  onOpened = () => undefined,
   title,
   footer,
   toolbar,
@@ -63,7 +62,6 @@ export const ModalDialog: FC<ModalDialogProps> = ({
   children,
   className = '',
   closeButtonLabel = 'Close',
-  onClose,
   isCloseButtonShown = true,
   style = {},
   ...dialogProps
@@ -92,23 +90,22 @@ export const ModalDialog: FC<ModalDialogProps> = ({
         root: bodyRef.current
       }
     )
+
     observeEdge(bodyTopEdgeRef.current, bodyObserverRef.current)
     observeEdge(bodyBottomEdgeRef.current, bodyObserverRef.current)
   }, [])
 
-  const onModalOpened = useCallback(
-    arg => {
-      initScrollShadows()
-      onOpened(arg)
-    },
-    [initScrollShadows, onOpened]
-  )
+  useEffect(() => bodyObserverRef.current?.disconnect, [])
 
-  useEffect(() => {
-    return () => {
-      bodyObserverRef.current?.disconnect()
-    }
-  }, [])
+  const onOpening: IDialogProps['onOpening'] = arg => {
+    initScrollShadows()
+    dialogProps.onOpening?.(arg)
+  }
+
+  const onClose: IDialogProps['onClose'] = arg => {
+    bodyObserverRef.current?.disconnect()
+    dialogProps.onClose?.(arg)
+  }
 
   const modifiers = []
 
@@ -142,7 +139,8 @@ export const ModalDialog: FC<ModalDialogProps> = ({
 
   return (
     <Dialog
-      onOpened={onModalOpened}
+      onOpening={onOpening}
+      onClose={onClose}
       autoFocus
       enforceFocus
       canEscapeKeyClose
@@ -179,7 +177,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
         </footer>
       )}
 
-      {onClose && isCloseButtonShown && (
+      {dialogProps.onClose && isCloseButtonShown && (
         <Button
           aria-label={closeButtonLabel}
           icon="Stroke"


### PR DESCRIPTION
Updates ModalDialog to fix escape key close, outside click close, and to render scroll shadows before transition.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
