### PR TITLE
chore: [CDS-53833]: override prop to reset value on fixed to expression type change

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.110.2",
+  "version": "3.111.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -112,7 +112,7 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
     mini,
     /**
      * By default, string fixed values are retained on changing from fixed to expresssion
-     * `resetExpressionOnFixedTypeChange`, if set to true, would reset these values
+     * If `resetExpressionOnFixedTypeChange` is set to true, these values would be reset
      */
     resetExpressionOnFixedTypeChange,
     ...layoutProps

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -51,6 +51,7 @@ export interface ExpressionAndRuntimeTypeProps<T = unknown> extends Omit<LayoutP
   name: string
   disabled?: boolean
   mini?: boolean
+  resetExpressionOnFixedTypeChange?: boolean
 }
 
 export interface FixedTypeComponentProps {
@@ -109,6 +110,11 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
     disabled,
     multitypeInputValue,
     mini,
+    /**
+     * By default, string fixed values are retained on changing from fixed to expresssion
+     * `resetExpressionOnFixedTypeChange`, if set to true, would reset these values
+     */
+    resetExpressionOnFixedTypeChange,
     ...layoutProps
   } = props
   const i18n = useMemo(() => Object.assign({}, i18nBase, _i18n), [_i18n])
@@ -133,7 +139,7 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
         break
       case MultiTypeInputType.EXPRESSION: {
         // retain value if switching from fixed to expression type
-        if (type === MultiTypeInputType.FIXED && typeof value === 'string') {
+        if (type === MultiTypeInputType.FIXED && !resetExpressionOnFixedTypeChange && typeof value === 'string') {
           _inputValue = value
         } else {
           _inputValue = defaultValueToReset


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
