### PR TITLE
fix: [CDS-53070]: BiLevelSelect component added for jenkins jobs

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.114.0",
+  "version": "3.115.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -32,8 +32,9 @@ import { AllowedTypes, AllowedTypesWithExecutionTime, MultiTypeInputMenu } from 
 import { SelectWithSubmenu, SelectWithSubmenuProps } from '../SelectWithSubmenu/SelectWithSubmenu'
 import { SelectWithSubmenuV2, SelectWithSubmenuPropsV2 } from '../SelectWithSubmenu/SelectWithSubmenuV2'
 import { MultiSelectWithSubmenu, MultiSelectWithSubmenuProps } from '../MultiSelectWithSubmenu/MultiSelectWithSubmenu'
+import { BiLevelSelect, BiLevelSelectProps, SelectWithBiLevelOption } from '../Select/BiLevelSelect'
 
-type AcceptableValue = boolean | string | number | SelectOption | string[] | MultiSelectOption[]
+type AcceptableValue = boolean | string | number | SelectOption | string[] | MultiSelectOption[] | BiLevelSelectProps
 
 export interface ExpressionAndRuntimeTypeProps<T = unknown> extends Omit<LayoutProps, 'onChange'> {
   value?: AcceptableValue
@@ -277,9 +278,36 @@ export function MultiTypeInputFixedTypeComponent(
   )
 }
 
+export function MultiTypeBiLevelInputFixedTypeComponent(
+  props: FixedTypeComponentProps & Partial<MultiTypeBiLevelInputProps['selectProps']>
+): React.ReactElement {
+  const { onChange, value, disabled, ...selectProps } = props
+  const { items = [] } = selectProps || {}
+  return (
+    <BiLevelSelect
+      usePortal={true}
+      {...selectProps}
+      className={cx(css.select, selectProps.className, {
+        [css.fixedValueInput]: MultiTypeInputType.FIXED ? true : false
+      })}
+      items={items}
+      value={value as SelectWithBiLevelOption}
+      disabled={disabled}
+      onChange={(item: SelectWithBiLevelOption) =>
+        onChange?.(item, MultiTypeInputValue.SELECT_OPTION, MultiTypeInputType.FIXED)
+      }
+    />
+  )
+}
+
 export interface MultiTypeInputProps
   extends Omit<ExpressionAndRuntimeTypeProps, 'fixedTypeComponent' | 'fixedTypeComponentProps'> {
   selectProps?: Omit<SelectProps, 'onChange' | 'value'>
+}
+
+export interface MultiTypeBiLevelInputProps
+  extends Omit<ExpressionAndRuntimeTypeProps, 'fixedTypeComponent' | 'fixedTypeComponentProps'> {
+  selectProps?: Omit<BiLevelSelectProps, 'onChange' | 'value'>
 }
 
 export function MultiTypeInput({ selectProps, ...rest }: MultiTypeInputProps): React.ReactElement {
@@ -288,6 +316,16 @@ export function MultiTypeInput({ selectProps, ...rest }: MultiTypeInputProps): R
       {...rest}
       fixedTypeComponentProps={selectProps}
       fixedTypeComponent={MultiTypeInputFixedTypeComponent}
+    />
+  )
+}
+
+export function MultiTypeBiLevelInput({ selectProps, ...rest }: MultiTypeBiLevelInputProps): React.ReactElement {
+  return (
+    <ExpressionAndRuntimeType
+      {...rest}
+      fixedTypeComponentProps={selectProps}
+      fixedTypeComponent={MultiTypeBiLevelInputFixedTypeComponent}
     />
   )
 }

--- a/packages/uicore/src/components/Select/BiLevelSelect.tsx
+++ b/packages/uicore/src/components/Select/BiLevelSelect.tsx
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import cx from 'classnames'
+import { Position, Classes } from '@blueprintjs/core'
+import { Suggest, ISuggestProps, IItemRendererProps } from '@blueprintjs/select'
+
+import css from './Select.css'
+import { Button } from '../../components/Button/Button'
+import { Icon, IconProps } from '@harness/icons'
+import { Utils } from '../../core/Utils'
+import { Text } from '../../components/Text/Text'
+import { Popover } from '../../components/Popover/Popover'
+
+export interface SelectWithBiLevelOption {
+  label: string
+  value: string | number | symbol
+  parentLabel?: string
+  parentValue?: string
+  icon?: IconProps
+  submenuItems?: SelectWithBiLevelOption[]
+  hasSubmenuItems?: boolean
+}
+
+export enum SelectSize {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large'
+}
+
+type BiLevelProps = ISuggestProps<SelectWithBiLevelOption>
+
+const Loading = Symbol('loading')
+
+export interface BiLevelSelectProps
+  extends Omit<
+    BiLevelProps,
+    | 'popoverProps'
+    | 'inputValueRenderer'
+    | 'itemRenderer'
+    | 'onItemSelect'
+    | 'query'
+    | 'selectedItem'
+    | 'items'
+    | 'activeItem'
+    | 'onActiveItemChange'
+  > {
+  inputValueRender?: BiLevelProps['inputValueRenderer']
+  itemRenderer?: BiLevelProps['itemRenderer']
+  onChange?: BiLevelProps['onItemSelect']
+  value?: BiLevelProps['selectedItem']
+  size?: SelectSize
+  items: BiLevelProps['items'] | (() => Promise<BiLevelProps['items']>)
+  allowCreatingNewItems?: boolean
+  name?: string
+  whenPopoverClosed?: (node: HTMLElement) => void
+  addClearBtn?: boolean
+  usePortal?: boolean
+  popoverClassName?: string
+  onQueryChange?: BiLevelProps['onQueryChange']
+  addTooltip?: boolean
+  borderless?: boolean
+  loadingItems?: boolean
+}
+
+function getIconSizeFromSelect(size: SelectSize = SelectSize.Medium) {
+  let iconSize = 16
+  if (size === SelectSize.Small) {
+    iconSize = 12
+  } else if (size === SelectSize.Large) {
+    iconSize = 18
+  }
+  return iconSize
+}
+
+export function defaultItemRenderer(
+  item: SelectWithBiLevelOption,
+  props: IItemRendererProps,
+  size: SelectSize = SelectSize.Medium
+): JSX.Element | null {
+  if (!props.modifiers.matchesPredicate) {
+    return null
+  }
+
+  if (item.value === Loading) {
+    return (
+      <li key="loading" className={cx(css.menuItem, css.loading)}>
+        Loading results...
+      </li>
+    )
+  }
+
+  return (
+    <li
+      key={item.value.toString()}
+      className={cx(
+        css.menuItem,
+        {
+          [css.active]: props.modifiers.active,
+          [css.disabled]: props.modifiers.disabled
+        },
+        { [css.menuItemSizeSmall]: size === SelectSize.Small },
+        { [css.menuItemSizeLarge]: size === SelectSize.Large }
+      )}
+      onClick={props.handleClick}>
+      {item.icon ? <Icon size={getIconSizeFromSelect(size)} {...item.icon} /> : null}
+      <Text className={css.menuItemLabel} lineClamp={1}>
+        {item.label}
+      </Text>
+    </li>
+  )
+}
+
+export function createNewItemFromQuery(query: string): SelectWithBiLevelOption {
+  return { label: query, value: query }
+}
+
+export function BiLevelSelect(props: BiLevelSelectProps): React.ReactElement {
+  const [query, setQuery] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+  const [items, setItems] = React.useState(Array.isArray(props.items) ? props.items : [])
+  const {
+    onChange,
+    value,
+    size,
+    itemRenderer,
+    addClearBtn,
+    whenPopoverClosed,
+    popoverClassName = '',
+    resetOnSelect = true,
+    resetOnClose = true,
+    addTooltip = false,
+    borderless = false,
+    loadingItems,
+    ...rest
+  } = props
+  const [item, setItem] = React.useState<SelectWithBiLevelOption | undefined | null>(undefined)
+
+  const showClearBtn =
+    !!addClearBtn &&
+    value !== null &&
+    value !== undefined &&
+    (value as any) !== '' &&
+    value?.value !== undefined &&
+    value?.value !== null &&
+    value?.value !== ''
+
+  React.useEffect(() => {
+    setItem(value)
+  }, [value])
+
+  function handleItemSelect(item: SelectWithBiLevelOption) {
+    if (item.value === Loading) {
+      return
+    }
+    if (typeof onChange === 'function') {
+      onChange(item)
+    } else {
+      setItem(item)
+    }
+  }
+
+  React.useEffect(() => {
+    if (Array.isArray(props.items)) {
+      setItems(props.items)
+    } else if (typeof props.items === 'function') {
+      setLoading(true)
+      const promise = props.items()
+
+      if (typeof promise.then === 'function') {
+        promise.then(results => {
+          setItems(results)
+          setLoading(false)
+        })
+      } else {
+        setLoading(false)
+      }
+    }
+  }, [props.items])
+
+  function createNewItemRenderer(
+    query: string,
+    _active: boolean,
+    handleClick: React.MouseEventHandler<HTMLElement>
+  ): JSX.Element | undefined {
+    if (loading || loadingItems) {
+      return (
+        <li key="loading" className={cx(css.menuItem, css.loading)}>
+          Loading results...
+        </li>
+      )
+    }
+
+    const isExactQueryElPresent = items.some(item => item.label === query)
+    if (!loading)
+      return (
+        <React.Fragment>
+          {items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase())).length === 0 ? (
+            <div className={css.noResultsFound}>No Match Found</div>
+          ) : null}
+          {props.allowCreatingNewItems && !isExactQueryElPresent && (
+            <Button
+              intent="primary"
+              minimal
+              text={query}
+              icon="plus"
+              className={css.createNewItemButton}
+              onClick={handleClick as React.MouseEventHandler<Element>}
+            />
+          )}
+        </React.Fragment>
+      )
+  }
+  const renderSuggestComponent = () => (
+    <Suggest
+      inputValueRenderer={opt => opt.label}
+      itemRenderer={(item: SelectWithBiLevelOption, props: IItemRendererProps) =>
+        itemRenderer?.(item, props) || defaultItemRenderer(item, props, size)
+      }
+      itemListPredicate={(query, items) =>
+        items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase()))
+      }
+      createNewItemFromQuery={props.createNewItemFromQuery || createNewItemFromQuery}
+      createNewItemRenderer={props.createNewItemRenderer || createNewItemRenderer}
+      noResults={<NoMatch />}
+      {...rest}
+      inputProps={{
+        onChange(e: React.ChangeEvent<HTMLInputElement>) {
+          setQuery(e.target.value)
+        },
+        value: query,
+        placeholder: Utils.getSelectComponentPlaceholder(rest?.inputProps?.placeholder),
+        leftElement: item?.icon ? <Icon size={getIconSizeFromSelect(size)} {...item?.icon} /> : undefined,
+        rightElement: (
+          <>
+            {!props.disabled && showClearBtn ? (
+              <Icon
+                name="main-delete"
+                onClick={(e: React.MouseEvent<HTMLHeadingElement, MouseEvent>) => {
+                  e.preventDefault()
+                  handleItemSelect({ value: '', label: '' })
+                }}
+                size={14}
+                padding={{ top: 'small', right: 'xsmall', bottom: 'small' }}
+              />
+            ) : null}
+            <Icon
+              name={'chevron-down'}
+              onClick={e => {
+                const input = e.currentTarget.parentElement?.previousElementSibling as HTMLInputElement
+                input?.focus()
+              }}
+              size={14}
+              padding={size === SelectSize.Small ? 'xsmall' : 'small'}
+            />
+          </>
+        ),
+        small: size === SelectSize.Small,
+        large: size === SelectSize.Large,
+        name: props.name,
+        ...props.inputProps
+      }}
+      resetOnSelect={resetOnSelect}
+      resetOnClose={resetOnClose}
+      items={loading ? [{ label: 'Loading...', value: Loading }] : items}
+      selectedItem={item}
+      onItemSelect={handleItemSelect}
+      query={query}
+      popoverProps={{
+        targetTagName: 'div',
+        fill: true,
+        usePortal: !!props.usePortal,
+        minimal: true,
+        position: Position.BOTTOM_LEFT,
+        className: cx(css.main, { [css.borderless]: borderless }),
+        popoverClassName: cx(css.popover, popoverClassName),
+        onClosed: whenPopoverClosed,
+        modifiers: {
+          preventOverflow: {
+            // This is required to always attach the portal to the start of the reference instead of the middle
+            escapeWithReference: !!props.usePortal
+          },
+          offset: {
+            // This is required to offset the portal after it is attached to the reference.
+            // By default the portal is positioned at top: 0, left:0 wrt it's reference
+            offset: props.usePortal ? '1 2' : 0
+          }
+        }
+      }}
+    />
+  )
+  const tooltipContent = item?.label ? (
+    <div className={css.tooltipContainer} color="white">
+      {item.label}
+    </div>
+  ) : (
+    ''
+  )
+  return addTooltip ? (
+    <Popover
+      boundary="viewport"
+      interactionKind="hover"
+      content={tooltipContent}
+      isDark={true}
+      fill={true}
+      popoverClassName={Classes.DARK}
+      position="bottom">
+      {renderSuggestComponent()}
+    </Popover>
+  ) : (
+    renderSuggestComponent()
+  )
+}
+
+export function NoMatch(): React.ReactElement {
+  return <li className={cx(css.menuItem, css.disabled)}>No matching results found</li>
+}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
