### PR TITLE
fix: [PL-32462]: increased tooltip icon margin for bigger hoverable area

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.120.0",
+  "version": "3.121.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/frameworks/Tooltip/Tooltip.css
+++ b/packages/uicore/src/frameworks/Tooltip/Tooltip.css
@@ -17,7 +17,7 @@
 }
 
 .tooltipIcon {
-  margin-left: var(--spacing-xsmall);
+  margin: 0 var(--spacing-xsmall) var(--spacing-xsmall) var(--spacing-xsmall);
   display: flex;
   position: relative;
 }


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/PL-32462
Increased tooltip icon margin for bigger hoverable area

Screenshots:
**BEFORE: Only left margin (& icon itself) for hover**
![image](https://user-images.githubusercontent.com/96057095/230606139-a8995db4-8854-4eba-9cd6-09d2a965986d.png)
![image](https://user-images.githubusercontent.com/96057095/230606152-bb2de8d5-335b-4874-b759-8f5cafb75eba.png)
![image](https://user-images.githubusercontent.com/96057095/230606164-e1491bb4-6ae4-4b92-9d82-1eb36ef29a00.png)

https://user-images.githubusercontent.com/96057095/230608282-85c4ec34-317f-447a-ad81-b3387c21c8e7.mov



**AFTER: Left, bottom & Right Margin (& icon itself) for hover. Not using top-margin as it misaligns the icon with respect to the text.**
![image](https://user-images.githubusercontent.com/96057095/230606193-9ce5039e-cac1-4cc9-a80a-43bb370d8bb5.png)
![image](https://user-images.githubusercontent.com/96057095/230606205-1640bca6-2b1b-4b26-8148-c96354ac3cfb.png)
![image](https://user-images.githubusercontent.com/96057095/230606222-e80143bf-d3f9-4063-ac55-4571bd6a3267.png)

https://user-images.githubusercontent.com/96057095/230608342-a60f44cc-a630-4ff5-8925-2e644e2af2d2.mov




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
