### PR TITLE
fix: [CDS-58678]: Added support for FormInput.Text to be used as Identifier field

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.124.0",
+  "version": "3.125.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -38,7 +38,11 @@ import css from './FormikForm.css'
 import i18n from './FormikForm.i18n'
 import { OverlaySpinner } from '../OverlaySpinner/OverlaySpinner'
 import { ColorPickerProps, ColorPicker } from '../ColorPicker/ColorPicker'
-import { InputWithIdentifier, InputWithIdentifierProps } from '../InputWithIdentifier/InputWithIdentifier'
+import {
+  InputWithIdentifier,
+  InputWithIdentifierProps,
+  getIdentifierFromName
+} from '../InputWithIdentifier/InputWithIdentifier'
 import {
   MultiTypeInputProps,
   MultiTypeInput,
@@ -677,10 +681,11 @@ export interface TextProps extends Omit<IFormGroupProps, 'labelFor'> {
   inputGroup?: Omit<IInputGroupProps & HTMLInputProps, 'name' | 'value' | 'onChange' | 'placeholder'>
   placeholder?: string
   onChange?: IInputGroupProps['onChange']
+  isIdentifier?: boolean
 }
 
 const Text = (props: TextProps & FormikContextProps<any>) => {
-  const { formik, name, ...restProps } = props
+  const { formik, name, isIdentifier = false, ...restProps } = props
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
@@ -716,10 +721,15 @@ const Text = (props: TextProps & FormikContextProps<any>) => {
           inputGroup?.onBlur?.(e)
         }}
         onChange={(e: React.FormEvent<HTMLInputElement>) => {
-          if (inputGroup?.type === 'number') {
-            formik?.setFieldValue(name, parseFloat(e.currentTarget.value))
+          if (isIdentifier) {
+            const identifier = getIdentifierFromName(e.currentTarget.value)
+            formik?.setFieldValue(name, identifier)
           } else {
-            formik?.setFieldValue(name, e.currentTarget.value)
+            if (inputGroup?.type === 'number') {
+              formik?.setFieldValue(name, parseFloat(e.currentTarget.value))
+            } else {
+              formik?.setFieldValue(name, e.currentTarget.value)
+            }
           }
           onChange?.(e)
         }}


### PR DESCRIPTION
Added `isIdentifier` optional boolean prop to `FormInput.Text` so that the field can be used as Identifier field and behave same as Id field in `InputWithIdentifier`

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
