### PR TITLE
feat: [PIE-9697]: Adding Overlay support in ModalDialog

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.126.0",
+  "version": "3.127.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.stories.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.stories.tsx
@@ -72,6 +72,35 @@ export const Basic: Story<ModalDialogProps> = () => {
 }
 Basic.storyName = 'Basic usage'
 
+export const BasicWithOverlay: Story<ModalDialogProps> = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return (
+    <>
+      <Button variation={ButtonVariation.PRIMARY} text="Open Dialog" onClick={() => setIsOpen(true)} />
+
+      <ModalDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="ModalDialog title"
+        showOverlay={true}
+        footer={
+          <Layout.Horizontal spacing="small">
+            <Button variation={ButtonVariation.PRIMARY} text="Option 1" />
+            <Button variation={ButtonVariation.SECONDARY} text="Option 2" />
+          </Layout.Horizontal>
+        }>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet architecto consectetur dolorem dolores eaque
+          illum iusto laboriosam, odit provident sapiente tenetur, veritatis. Aperiam blanditiis cum dignissimos eveniet
+          praesentium repellendus similique?
+        </p>
+      </ModalDialog>
+    </>
+  )
+}
+BasicWithOverlay.storyName = 'Basic usage with overlay'
+
 export const WithLongContent: Story<ModalDialogProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
 

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.test.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.test.tsx
@@ -33,15 +33,15 @@ describe('ModalDialog', () => {
     test('it should set the noHeader modifier when no title or toolbar are passed', async () => {
       renderComponent()
 
-      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noHeader')
+      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noHeader')
     })
 
     test('it should not set the noHeader modifier when title is passed', async () => {
       const { rerender } = renderComponent({ title: 'Test' })
-      expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noHeader')
+      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).not.toHaveClass('noHeader')
 
       rerender(<ModalDialog isOpen={true} />)
-      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noHeader')
+      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noHeader')
     })
   })
 
@@ -64,7 +64,7 @@ describe('ModalDialog', () => {
     test('it should add the class noToolbar when toolbar is omitted', async () => {
       renderComponent()
 
-      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noToolbar')
+      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noToolbar')
     })
   })
 
@@ -93,10 +93,10 @@ describe('ModalDialog', () => {
 
     test('it should set the noFooter modifier when no footer is passed', async () => {
       const { rerender } = renderComponent()
-      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noFooter')
+      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noFooter')
 
       rerender(<ModalDialog isOpen={true} footer="test" />)
-      expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noFooter')
+      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).not.toHaveClass('noFooter')
     })
   })
 
@@ -142,7 +142,7 @@ describe('ModalDialog', () => {
       const width = 100
       renderComponent({ width })
 
-      const dialog = screen.getByTestId('modaldialog-body').parentElement
+      const dialog = screen.getByTestId('modaldialog-body').parentElement?.parentElement
 
       expect(dialog).toHaveStyle({ width: `${width}px` })
     })
@@ -151,7 +151,7 @@ describe('ModalDialog', () => {
       const height = 100
       renderComponent({ height })
 
-      const dialog = screen.getByTestId('modaldialog-body').parentElement
+      const dialog = screen.getByTestId('modaldialog-body').parentElement?.parentElement
 
       expect(dialog).toHaveAttribute('style', expect.stringContaining(`--ModalDialog-Height: ${height}px`))
     })

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -10,6 +10,7 @@ import { Dialog, IDialogProps } from '@blueprintjs/core'
 import cx from 'classnames'
 import { FontVariation } from '@harness/design-system'
 import { Heading } from '../Heading/Heading'
+import { OverlaySpinner } from '../OverlaySpinner/OverlaySpinner'
 import { Button, ButtonVariation } from '../Button/Button'
 
 import css from './ModalDialog.css'
@@ -51,6 +52,10 @@ export interface ModalDialogProps extends IDialogProps {
    * Optional override of the accessible label of the close button of the modal. Defaults to "Close"
    */
   closeButtonLabel?: string
+  /**
+   * Optional: when set to true a overlay is shown over the entire modal
+   */
+  showOverlay?: boolean
 }
 
 export const ModalDialog: FC<ModalDialogProps> = ({
@@ -63,6 +68,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
   className = '',
   closeButtonLabel = 'Close',
   isCloseButtonShown = true,
+  showOverlay = false,
   style = {},
   ...dialogProps
 }) => {
@@ -149,44 +155,46 @@ export const ModalDialog: FC<ModalDialogProps> = ({
       className={cx(className, css.container, ...modifiers)}
       style={style}
       {...dialogProps}>
-      {title && (
-        <header className={css.header} data-testid="modaldialog-header">
-          <Heading level={3} font={{ variation: FontVariation.H3 }}>
-            {title}
-          </Heading>
-        </header>
-      )}
+      <OverlaySpinner show={showOverlay}>
+        {title && (
+          <header className={css.header} data-testid="modaldialog-header">
+            <Heading level={3} font={{ variation: FontVariation.H3 }}>
+              {title}
+            </Heading>
+          </header>
+        )}
 
-      {toolbar && (
-        <aside className={css.toolbar} data-testid="modaldialog-toolbar">
-          {toolbar}
-        </aside>
-      )}
+        {toolbar && (
+          <aside className={css.toolbar} data-testid="modaldialog-toolbar">
+            {toolbar}
+          </aside>
+        )}
 
-      <div className={cx(css.body, bodyShadowClass)} data-testid="modaldialog-body" ref={bodyRef}>
-        <div className={css.bodyContent}>
-          <div ref={bodyTopEdgeRef} data-position="top" />
-          <div>{children}</div>
-          <div ref={bodyBottomEdgeRef} data-position="bottom" />
+        <div className={cx(css.body, bodyShadowClass)} data-testid="modaldialog-body" ref={bodyRef}>
+          <div className={css.bodyContent}>
+            <div ref={bodyTopEdgeRef} data-position="top" />
+            <div>{children}</div>
+            <div ref={bodyBottomEdgeRef} data-position="bottom" />
+          </div>
         </div>
-      </div>
 
-      {footer && (
-        <footer className={css.footer} data-testid="modaldialog-footer">
-          {footer}
-        </footer>
-      )}
+        {footer && (
+          <footer className={css.footer} data-testid="modaldialog-footer">
+            {footer}
+          </footer>
+        )}
 
-      {dialogProps.onClose && isCloseButtonShown && (
-        <Button
-          aria-label={closeButtonLabel}
-          icon="Stroke"
-          intent="primary"
-          variation={ButtonVariation.ICON}
-          onClick={() => onClose()}
-          className={css.closeButton}
-        />
-      )}
+        {dialogProps.onClose && isCloseButtonShown && (
+          <Button
+            aria-label={closeButtonLabel}
+            icon="Stroke"
+            intent="primary"
+            variation={ButtonVariation.ICON}
+            onClick={() => onClose()}
+            className={css.closeButton}
+          />
+        )}
+      </OverlaySpinner>
     </Dialog>
   )
 }

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -53,7 +53,7 @@ export interface ModalDialogProps extends IDialogProps {
    */
   closeButtonLabel?: string
   /**
-   * Optional: when set to true a overlay is shown over the entire modal
+   * Optional: when set to true an overlay is shown over the entire modal
    */
   showOverlay?: boolean
 }


### PR DESCRIPTION
**Changes to support the behaviour :** 

https://user-images.githubusercontent.com/63278928/232852497-6a30e74f-8449-4e37-b255-53407c976697.mov

Behaviour with current support where only content can be wrapped in Overlay by consumer ( not header and footer)

https://user-images.githubusercontent.com/63278928/232853412-51596975-5516-4a3d-aa23-bc7b5863cdae.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
