### PR TITLE
fix: [PIE-9697]: Fix for modal dialog with Overlay

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.127.0",
+  "version": "3.128.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -22,6 +22,16 @@
     'footer';
 }
 
+.overlayContainer {
+  overflow: auto;
+  pointer-events: none;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
+}
+
 .noHeader.noFooter .body {
   background: none;
 }

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.stories.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.stories.tsx
@@ -101,6 +101,57 @@ export const BasicWithOverlay: Story<ModalDialogProps> = () => {
 }
 BasicWithOverlay.storyName = 'Basic usage with overlay'
 
+const getLongElement = () => {
+  return (
+    <>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab aliquid aperiam beatae consequuntur delectus
+        dolorem doloribus ea eius itaque, iure modi numquam odio, odit optio placeat provident quisquam ratione sed!
+      </p>
+      <p>
+        Autem consequatur deserunt dignissimos earum eos fugit hic incidunt iste iusto magni neque nihil non nostrum,
+        obcaecati officia officiis praesentium quae quas quia quibusdam quo suscipit tempore totam vero voluptatum.
+      </p>
+      <p>
+        Corporis deserunt earum est, facere ipsa itaque nemo nulla obcaecati optio perferendis possimus quae quas quasi
+        quod ratione tempore voluptates? Beatae commodi enim inventore numquam officia pariatur quos rem voluptates.
+      </p>
+      <p>
+        Corporis eaque inventore laboriosam quod reprehenderit similique, ut? A asperiores atque, delectus deleniti ea,
+        esse explicabo iure maxime nesciunt nostrum officiis omnis quae quis reiciendis repellat repudiandae suscipit
+        velit voluptatibus.
+      </p>
+      <p>
+        Accusantium aliquam architecto, dolorem eius esse iste odio repellat tempore. Accusantium, architecto asperiores
+        dicta eligendi error, est eum facere fuga inventore ipsa ipsum, magnam modi nulla quidem reiciendis voluptate
+        voluptates.
+      </p>
+      <p>
+        Corporis doloremque enim excepturi exercitationem laborum nesciunt nulla odio praesentium quae, quis, recusandae
+        reiciendis repellat, ullam. At dolore eveniet maiores nobis nulla, numquam obcaecati tempora vero! Dicta illo
+        minus voluptatum.
+      </p>
+      <p>
+        Cum cupiditate doloribus exercitationem expedita iusto laboriosam libero, nam quam voluptas! Amet aut dolorum
+        illum tempora. Architecto asperiores, debitis eaque exercitationem facere fugit ipsa mollitia nam nobis quasi,
+        sequi ullam?
+      </p>
+      <p>
+        Aperiam delectus harum impedit ipsa itaque, laboriosam maiores minima nam necessitatibus nisi nobis odio qui
+        saepe similique sit tempore, ullam? Adipisci dolorem doloribus eius eveniet fugiat illum ipsum repellat sint.
+      </p>
+      <p>
+        Ab cum distinctio eveniet iste minima non quisquam, recusandae repellendus suscipit totam voluptas voluptate! Ad
+        autem corporis cumque dolore dolorem illum in iure iusto, odit optio repudiandae soluta vero voluptatum.
+      </p>
+      <p>
+        Animi earum fuga, iusto labore nisi non provident quam qui quo quos recusandae temporibus tenetur? Debitis,
+        fugit harum maxime necessitatibus nobis quos repudiandae sequi. Eum minus quaerat quas quia ut!
+      </p>
+    </>
+  )
+}
+
 export const WithLongContent: Story<ModalDialogProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
@@ -118,56 +169,37 @@ export const WithLongContent: Story<ModalDialogProps> = () => {
             <Button variation={ButtonVariation.SECONDARY} text="Option 2" />
           </Layout.Horizontal>
         }>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab aliquid aperiam beatae consequuntur delectus
-          dolorem doloribus ea eius itaque, iure modi numquam odio, odit optio placeat provident quisquam ratione sed!
-        </p>
-        <p>
-          Autem consequatur deserunt dignissimos earum eos fugit hic incidunt iste iusto magni neque nihil non nostrum,
-          obcaecati officia officiis praesentium quae quas quia quibusdam quo suscipit tempore totam vero voluptatum.
-        </p>
-        <p>
-          Corporis deserunt earum est, facere ipsa itaque nemo nulla obcaecati optio perferendis possimus quae quas
-          quasi quod ratione tempore voluptates? Beatae commodi enim inventore numquam officia pariatur quos rem
-          voluptates.
-        </p>
-        <p>
-          Corporis eaque inventore laboriosam quod reprehenderit similique, ut? A asperiores atque, delectus deleniti
-          ea, esse explicabo iure maxime nesciunt nostrum officiis omnis quae quis reiciendis repellat repudiandae
-          suscipit velit voluptatibus.
-        </p>
-        <p>
-          Accusantium aliquam architecto, dolorem eius esse iste odio repellat tempore. Accusantium, architecto
-          asperiores dicta eligendi error, est eum facere fuga inventore ipsa ipsum, magnam modi nulla quidem reiciendis
-          voluptate voluptates.
-        </p>
-        <p>
-          Corporis doloremque enim excepturi exercitationem laborum nesciunt nulla odio praesentium quae, quis,
-          recusandae reiciendis repellat, ullam. At dolore eveniet maiores nobis nulla, numquam obcaecati tempora vero!
-          Dicta illo minus voluptatum.
-        </p>
-        <p>
-          Cum cupiditate doloribus exercitationem expedita iusto laboriosam libero, nam quam voluptas! Amet aut dolorum
-          illum tempora. Architecto asperiores, debitis eaque exercitationem facere fugit ipsa mollitia nam nobis quasi,
-          sequi ullam?
-        </p>
-        <p>
-          Aperiam delectus harum impedit ipsa itaque, laboriosam maiores minima nam necessitatibus nisi nobis odio qui
-          saepe similique sit tempore, ullam? Adipisci dolorem doloribus eius eveniet fugiat illum ipsum repellat sint.
-        </p>
-        <p>
-          Ab cum distinctio eveniet iste minima non quisquam, recusandae repellendus suscipit totam voluptas voluptate!
-          Ad autem corporis cumque dolore dolorem illum in iure iusto, odit optio repudiandae soluta vero voluptatum.
-        </p>
-        <p>
-          Animi earum fuga, iusto labore nisi non provident quam qui quo quos recusandae temporibus tenetur? Debitis,
-          fugit harum maxime necessitatibus nobis quos repudiandae sequi. Eum minus quaerat quas quia ut!
-        </p>
+        {getLongElement()}
       </ModalDialog>
     </>
   )
 }
 WithLongContent.storyName = 'With long content'
+
+export const WithLongContentAndOverlay: Story<ModalDialogProps> = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return (
+    <>
+      <Button variation={ButtonVariation.PRIMARY} text="Open Dialog" onClick={() => setIsOpen(true)} />
+
+      <ModalDialog
+        isOpen={isOpen}
+        showOverlay={true}
+        onClose={() => setIsOpen(false)}
+        title="ModalDialog title"
+        footer={
+          <Layout.Horizontal spacing="small">
+            <Button variation={ButtonVariation.PRIMARY} text="Option 1" />
+            <Button variation={ButtonVariation.SECONDARY} text="Option 2" />
+          </Layout.Horizontal>
+        }>
+        {getLongElement()}
+      </ModalDialog>
+    </>
+  )
+}
+WithLongContentAndOverlay.storyName = 'With long content and overlay'
 
 export const WithLongTitle: Story<ModalDialogProps> = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false)

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.test.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.test.tsx
@@ -33,15 +33,15 @@ describe('ModalDialog', () => {
     test('it should set the noHeader modifier when no title or toolbar are passed', async () => {
       renderComponent()
 
-      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noHeader')
+      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noHeader')
     })
 
     test('it should not set the noHeader modifier when title is passed', async () => {
       const { rerender } = renderComponent({ title: 'Test' })
-      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).not.toHaveClass('noHeader')
+      expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noHeader')
 
       rerender(<ModalDialog isOpen={true} />)
-      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noHeader')
+      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noHeader')
     })
   })
 
@@ -64,7 +64,7 @@ describe('ModalDialog', () => {
     test('it should add the class noToolbar when toolbar is omitted', async () => {
       renderComponent()
 
-      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noToolbar')
+      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noToolbar')
     })
   })
 
@@ -93,10 +93,10 @@ describe('ModalDialog', () => {
 
     test('it should set the noFooter modifier when no footer is passed', async () => {
       const { rerender } = renderComponent()
-      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).toHaveClass('noFooter')
+      expect(screen.getByTestId('modaldialog-body').parentElement).toHaveClass('noFooter')
 
       rerender(<ModalDialog isOpen={true} footer="test" />)
-      expect(screen.getByTestId('modaldialog-body').parentElement?.parentElement).not.toHaveClass('noFooter')
+      expect(screen.getByTestId('modaldialog-body').parentElement).not.toHaveClass('noFooter')
     })
   })
 
@@ -142,7 +142,7 @@ describe('ModalDialog', () => {
       const width = 100
       renderComponent({ width })
 
-      const dialog = screen.getByTestId('modaldialog-body').parentElement?.parentElement
+      const dialog = screen.getByTestId('modaldialog-body').parentElement
 
       expect(dialog).toHaveStyle({ width: `${width}px` })
     })
@@ -151,7 +151,7 @@ describe('ModalDialog', () => {
       const height = 100
       renderComponent({ height })
 
-      const dialog = screen.getByTestId('modaldialog-body').parentElement?.parentElement
+      const dialog = screen.getByTestId('modaldialog-body').parentElement
 
       expect(dialog).toHaveAttribute('style', expect.stringContaining(`--ModalDialog-Height: ${height}px`))
     })

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -143,19 +143,9 @@ export const ModalDialog: FC<ModalDialogProps> = ({
     return ''
   }, [scrollShadows])
 
-  return (
-    <Dialog
-      onOpening={onOpening}
-      onClose={onClose}
-      autoFocus
-      enforceFocus
-      canEscapeKeyClose
-      canOutsideClickClose
-      usePortal
-      className={cx(className, css.container, ...modifiers)}
-      style={style}
-      {...dialogProps}>
-      <OverlaySpinner show={showOverlay}>
+  const modalContent = useMemo(() => {
+    return (
+      <>
         {title && (
           <header className={css.header} data-testid="modaldialog-header">
             <Heading level={3} font={{ variation: FontVariation.H3 }}>
@@ -163,7 +153,6 @@ export const ModalDialog: FC<ModalDialogProps> = ({
             </Heading>
           </header>
         )}
-
         {toolbar && (
           <aside className={css.toolbar} data-testid="modaldialog-toolbar">
             {toolbar}
@@ -194,7 +183,29 @@ export const ModalDialog: FC<ModalDialogProps> = ({
             className={css.closeButton}
           />
         )}
-      </OverlaySpinner>
+      </>
+    )
+  }, [title, toolbar, children, footer])
+
+  return (
+    <Dialog
+      onOpening={onOpening}
+      onClose={onClose}
+      autoFocus
+      enforceFocus
+      canEscapeKeyClose
+      canOutsideClickClose
+      usePortal
+      className={cx(className, css.container, ...modifiers)}
+      style={{ ...style, ...{ maxHeight: '400px' } }}
+      {...dialogProps}>
+      {showOverlay ? (
+        <OverlaySpinner className={css.overlayContainer} show={true}>
+          {modalContent}
+        </OverlaySpinner>
+      ) : (
+        modalContent
+      )}
     </Dialog>
   )
 }

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -197,7 +197,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
       canOutsideClickClose
       usePortal
       className={cx(className, css.container, ...modifiers)}
-      style={{ ...style, ...{ maxHeight: '400px' } }}
+      style={style}
       {...dialogProps}>
       {showOverlay ? (
         <OverlaySpinner className={css.overlayContainer} show={true}>

--- a/packages/uicore/src/components/OverlaySpinner/OverlaySpinner.tsx
+++ b/packages/uicore/src/components/OverlaySpinner/OverlaySpinner.tsx
@@ -8,16 +8,18 @@
 import React from 'react'
 import css from './OverlaySpinner.css'
 import { ISpinnerProps, Spinner } from '@blueprintjs/core'
+import cx from 'classnames'
 
 export interface OverlaySpinnerProps extends ISpinnerProps {
   show: boolean
   children: React.ReactNode
+  className?: string
 }
 
 export const OverlaySpinner: React.FC<OverlaySpinnerProps> = props => {
-  const { show, children, ...rest } = props
+  const { show, children, className = '', ...rest } = props
   return (
-    <div className={css.overlaySpinner}>
+    <div className={cx(css.overlaySpinner, className)}>
       {children}
       {show ? (
         <div className={css.overlay}>


### PR DESCRIPTION
[Earlier changes](https://github.com/harness/uicore/pull/1031) were breaking modal with long contents.

<img width="718" alt="Screenshot 2023-04-19 at 2 06 53 PM" src="https://user-images.githubusercontent.com/63278928/233018315-ec8c6233-7557-4ce1-854f-a1859d678247.png">

- Now without overlay, there is no change in DOM and behaviour.
- With overlay, we have handled the long content behind overlay by CSS.

**After fix:** 

https://user-images.githubusercontent.com/63278928/233017003-6fa0ef31-809b-4a7d-9eb5-79a057d6151b.mov



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
