### PR TITLE
fix: [PIE-9318]: Corrected useMemo dependency introduced in last PR

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.129.1",
+  "version": "3.129.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -143,7 +143,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
     return ''
   }, [scrollShadows])
 
-  const modalContent = useMemo(() => {
+  const modalContent = () => {
     return (
       <>
         {title && (
@@ -185,7 +185,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
         )}
       </>
     )
-  }, [title, toolbar, children, footer])
+  }
 
   return (
     <Dialog

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -143,7 +143,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
     return ''
   }, [scrollShadows])
 
-  const modalContent = () => {
+  const modalContent = useMemo(() => {
     return (
       <>
         {title && (
@@ -185,7 +185,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
         )}
       </>
     )
-  }
+  }, [title, toolbar, children, footer, bodyShadowClass, bodyTopEdgeRef, bodyBottomEdgeRef, closeButtonLabel, onClose])
 
   return (
     <Dialog


### PR DESCRIPTION

Removing useMemo introduced in [previous PR](https://github.com/harness/uicore/pull/1032/files#diff-a1c84da032777acb9627a2bbf2bf4efc9b65d29361cde2ba747f5ced9e432fa9L146) due to side effects

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
