### PR TITLE
fix: [PIE-9318]: Removing memo in modalContent introduced in last PR

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.129.1",
+  "version": "3.129.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -143,49 +143,47 @@ export const ModalDialog: FC<ModalDialogProps> = ({
     return ''
   }, [scrollShadows])
 
-  const modalContent = useMemo(() => {
-    return (
-      <>
-        {title && (
-          <header className={css.header} data-testid="modaldialog-header">
-            <Heading level={3} font={{ variation: FontVariation.H3 }}>
-              {title}
-            </Heading>
-          </header>
-        )}
-        {toolbar && (
-          <aside className={css.toolbar} data-testid="modaldialog-toolbar">
-            {toolbar}
-          </aside>
-        )}
+  const modalContent = (
+    <>
+      {title && (
+        <header className={css.header} data-testid="modaldialog-header">
+          <Heading level={3} font={{ variation: FontVariation.H3 }}>
+            {title}
+          </Heading>
+        </header>
+      )}
+      {toolbar && (
+        <aside className={css.toolbar} data-testid="modaldialog-toolbar">
+          {toolbar}
+        </aside>
+      )}
 
-        <div className={cx(css.body, bodyShadowClass)} data-testid="modaldialog-body" ref={bodyRef}>
-          <div className={css.bodyContent}>
-            <div ref={bodyTopEdgeRef} data-position="top" />
-            <div>{children}</div>
-            <div ref={bodyBottomEdgeRef} data-position="bottom" />
-          </div>
+      <div className={cx(css.body, bodyShadowClass)} data-testid="modaldialog-body" ref={bodyRef}>
+        <div className={css.bodyContent}>
+          <div ref={bodyTopEdgeRef} data-position="top" />
+          <div>{children}</div>
+          <div ref={bodyBottomEdgeRef} data-position="bottom" />
         </div>
+      </div>
 
-        {footer && (
-          <footer className={css.footer} data-testid="modaldialog-footer">
-            {footer}
-          </footer>
-        )}
+      {footer && (
+        <footer className={css.footer} data-testid="modaldialog-footer">
+          {footer}
+        </footer>
+      )}
 
-        {dialogProps.onClose && isCloseButtonShown && (
-          <Button
-            aria-label={closeButtonLabel}
-            icon="Stroke"
-            intent="primary"
-            variation={ButtonVariation.ICON}
-            onClick={() => onClose()}
-            className={css.closeButton}
-          />
-        )}
-      </>
-    )
-  }, [title, toolbar, children, footer])
+      {dialogProps.onClose && isCloseButtonShown && (
+        <Button
+          aria-label={closeButtonLabel}
+          icon="Stroke"
+          intent="primary"
+          variation={ButtonVariation.ICON}
+          onClick={() => onClose()}
+          className={css.closeButton}
+        />
+      )}
+    </>
+  )
 
   return (
     <Dialog


### PR DESCRIPTION

Removing useMemo introduced in [previous PR](https://github.com/harness/uicore/pull/1032/files#diff-a1c84da032777acb9627a2bbf2bf4efc9b65d29361cde2ba747f5ced9e432fa9L146) due to side effects

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
