### PR TITLE
fix: init scroll shadows without depending on blueprint dialog lifecycle

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.129.2",
+  "version": "3.129.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
ModalDialog no longer relies on blueprint dialog's lifecycle callbacks for creating and removing scroll shadows. This fixes an issue with incorrect scroll shadows in some usages.

