### PR TITLE
fix: [fix_modaldialog]: Added function check before invoking

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.129.3",
+  "version": "3.129.4",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -8,6 +8,7 @@
 import React, { FC, ReactNode, useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import { Dialog, IDialogProps } from '@blueprintjs/core'
 import cx from 'classnames'
+import { isFunction } from 'lodash-es'
 import { FontVariation } from '@harness/design-system'
 import { Heading } from '../Heading/Heading'
 import { OverlaySpinner } from '../OverlaySpinner/OverlaySpinner'
@@ -83,7 +84,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
   const initScrollShadows = useCallback(() => {
     if (!bodyRef.current) return
 
-    bodyObserverRef.current?.disconnect()
+    isFunction(bodyObserverRef.current?.disconnect) && bodyObserverRef.current?.disconnect()
     bodyObserverRef.current = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
@@ -107,7 +108,7 @@ export const ModalDialog: FC<ModalDialogProps> = ({
   const bodyRefCallback = useCallback(
     (el: HTMLDivElement | null) => {
       if (!el) {
-        return bodyObserverRef.current?.disconnect()
+        return isFunction(bodyObserverRef.current?.disconnect) && bodyObserverRef.current?.disconnect()
       }
       bodyRef.current = el
       initScrollShadows()


### PR DESCRIPTION
[Earlier change](https://github.com/harness/uicore/pull/1041) were leading to jest failure with below error : 

```
TypeError: t.disconnect is not a function

      at node_modules/@harness/uicore/dist/webpack:/@harness/uicore/src/components/ModalDialog/ModalDialog.css:2:391
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:3945:14)
```


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
