### PR TITLE
fix: [CDS-68201]: add portal support for SplitButton

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.129.4",
+  "version": "3.129.5",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.129.5",
+  "version": "3.130.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/SplitButton/SplitButton.tsx
+++ b/packages/uicore/src/components/SplitButton/SplitButton.tsx
@@ -16,6 +16,7 @@ type SplitButtonProps = Omit<ButtonProps, 'rightIcon'> & {
   className?: string
   dropdownDisabled?: boolean
   popoverProps?: PopoverProps
+  usePortal?: boolean
 }
 
 export const SplitButton: React.FC<SplitButtonProps> = ({
@@ -29,6 +30,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
   disabled,
   dropdownDisabled,
   popoverProps,
+  usePortal = false,
   ...commonProps
 }) => {
   const [isOptionsOpen, setOptionsOpen] = React.useState(false)
@@ -58,7 +60,7 @@ export const SplitButton: React.FC<SplitButtonProps> = ({
             setOptionsOpen(nextOpenState)
           }}
           content={<Menu>{children}</Menu>}
-          usePortal={false}
+          usePortal={usePortal}
           minimal={true}
           fill={false}
           position={Position.BOTTOM_RIGHT}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
