### PR TITLE
fix: [CDS-68849]: Do not allow expression type if allowableTypes array is defined and expression type is not present in allowableTypes array

### DIFF
--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -92,7 +92,14 @@ export const getMultiTypeFromValue = (
 
       return MultiTypeInputType.RUNTIME
     }
-    if (isValueAnExpression(value)) return MultiTypeInputType.EXPRESSION
+    // Do not allow expression type if allowableTypes array is defined and expression type is not present in allowableTypes array
+    if (
+      (!Array.isArray(allowableTypes) && isValueAnExpression(value)) ||
+      (Array.isArray(allowableTypes) &&
+        isValueAnExpression(value) &&
+        (allowableTypes as AllowedTypesWithExecutionTime[]).includes(MultiTypeInputType.EXPRESSION))
+    )
+      return MultiTypeInputType.EXPRESSION
   } else if (Array.isArray(value) && supportListOfExpressionsBehaviour) {
     // To support list of expressions
     if (value.some((item: string | MultiSelectOption) => typeof item === 'string' && isValueAnExpression(item)))


### PR DESCRIPTION
before
<img width="624" alt="image" src="https://github.com/harness/uicore/assets/96036463/4cae697a-9158-4db3-bc40-a58c0c485200">

after
<img width="659" alt="image" src="https://github.com/harness/uicore/assets/96036463/140182ff-6263-475e-a0ef-74c8953aea09">

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
