### PR TITLE
feat: [PL-32524]: improve readability of warning toasts

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.135.0",
+  "version": "3.135.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/hooks/useToaster/useToaster.css
+++ b/packages/uicore/src/hooks/useToaster/useToaster.css
@@ -29,7 +29,7 @@
 
   /* colors */
   :global(.bp3-toast.bp3-intent-warning) {
-    background-color: var(--yellow-600);
+    background-color: var(--orange-500);
   }
   :global(.bp3-toast.bp3-intent-danger) {
     background-color: var(--red-600);

--- a/packages/uicore/src/hooks/useToaster/useToaster.stories.tsx
+++ b/packages/uicore/src/hooks/useToaster/useToaster.stories.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import type { Meta, Story } from '@storybook/react'
+import { Button } from '../../'
+import { useToaster } from './useToaster'
+
+export default {
+  title: 'Hooks / useToaster'
+} as Meta
+
+export const Basic: Story = args => {
+  const { showError, showPrimary, showSuccess, showWarning } = useToaster()
+  return (
+    <>
+      <Button
+        onClick={() => {
+          showPrimary(args.message, args.timeout)
+        }}>
+        Primary
+      </Button>
+      <Button
+        onClick={() => {
+          showSuccess(args.message, args.timeout)
+        }}>
+        Success
+      </Button>
+      <Button
+        onClick={() => {
+          showWarning(args.message, args.timeout)
+        }}>
+        Warning
+      </Button>
+      <Button
+        onClick={() => {
+          showError(args.message, args.timeout)
+        }}>
+        Error
+      </Button>
+    </>
+  )
+}
+
+Basic.args = {
+  message: 'This is a toast message',
+  timeout: 5000
+}


### PR DESCRIPTION
- Makes the warning toast background orange instead of yellow
- Adds stories for toaster hook to improve documentation

Old warning:
![image](https://github.com/harness/uicore/assets/47316575/94d5c5ba-593e-4e67-9773-c618f8f851e9)

New Toasts:
<img width="265" alt="Screenshot 2023-05-23 at 5 03 32 PM" src="https://github.com/harness/uicore/assets/47316575/d2fe609e-e41e-4058-93d7-a1c9f3d5bffb">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
