### PR TITLE
feat: add AccordionTab component + controlled accordion support in Accordion

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.135.3",
+  "version": "3.136.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/AccordionTabs/AccordionTabs.stories.tsx
+++ b/packages/uicore/src/components/AccordionTabs/AccordionTabs.stories.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+
+import { AccordionTabs, AccordionTabsProps } from './AccordionTabs'
+
+export default {
+  title: 'Components/AccordionTabs',
+  component: AccordionTabs
+} as Meta
+
+const Template: Story<AccordionTabsProps> = args => {
+  const [selectedTabId, setSelectedTabId] = React.useState(args.tabsProps.selectedTabId)
+
+  const handleTabChange = (newTabId: string, prevTabId: string, event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    setSelectedTabId(newTabId)
+    args.tabsProps.onChange?.(newTabId, prevTabId, event)
+  }
+
+  const handleAccordionChange = (tab: string) => {
+    setSelectedTabId(tab)
+    args.accordionProps.onChange?.(tab)
+  }
+
+  return (
+    <AccordionTabs
+      {...args}
+      tabsProps={{ ...args.tabsProps, selectedTabId, onChange: handleTabChange }}
+      accordionProps={{
+        ...args.accordionProps,
+        controlledActiveId: selectedTabId as string,
+        onChange: handleAccordionChange
+      }}
+    />
+  )
+}
+
+export const Basic = Template.bind({})
+Basic.args = {
+  tabList: [
+    {
+      id: 'tab1',
+      title: 'Tab 1',
+      panel: <div>Tab 1 Content</div>
+    },
+    {
+      id: 'tab2',
+      title: 'Tab 2',
+      panel: <span>Tab 2 Content</span>
+    },
+    {
+      id: 'tab3',
+      title: 'Tab 3',
+      panel: <div>Tab 3 Content</div>
+    },
+    {
+      id: 'tab4',
+      title: 'Tab 4',
+      panel: <span>Tab 4 Content</span>
+    }
+  ],
+  tabsProps: {
+    id: 'tabs',
+    selectedTabId: 'tab1',
+    onChange: (newTabId, prevTabId) => {
+      // Handle tab change
+      // eslint-disable-next-line no-console
+      console.log('changed tabs', newTabId, prevTabId)
+    }
+  },
+  accordionProps: {
+    onChange: tabs => {
+      // Handle accordion panel change
+      // eslint-disable-next-line no-console
+      console.log('changed accordion', tabs)
+    },
+    controlledActiveId: 'tab1'
+  }
+}

--- a/packages/uicore/src/components/AccordionTabs/AccordionTabs.test.tsx
+++ b/packages/uicore/src/components/AccordionTabs/AccordionTabs.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AccordionTabs, TabListProps } from './AccordionTabs'
+
+describe('AccordionTabs', () => {
+  const tabList: TabListProps[] = [
+    {
+      id: 'panel-1',
+      title: 'Tab 1',
+      panel: <div>Tab 1 Content</div>
+    },
+    {
+      id: 'panel-2',
+      title: 'Tab 2',
+      panel: <span>Tab 2 Content</span>
+    }
+  ]
+
+  const tabsProps = {
+    id: 'tabs',
+    selectedTabId: 'panel-1',
+    onChange: jest.fn()
+  }
+
+  const accordionProps = {
+    onChange: jest.fn(),
+    controlledActiveId: 'panel-1'
+  }
+
+  it('renders the tab titles and panels correctly', () => {
+    render(<AccordionTabs tabList={tabList} tabsProps={tabsProps} accordionProps={accordionProps} />)
+
+    // Assert that the tab titles are rendered
+    expect(screen.getByRole('tab', { name: 'Tab 1' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Tab 2' })).toBeInTheDocument()
+
+    // Assert that the first tab panel is rendered and the second one is not
+    expect(screen.getByText('Tab 1 Content')).toBeInTheDocument()
+    expect(screen.queryByText('Tab 2 Content')).not.toBeInTheDocument()
+  })
+
+  it('switches between tabs when clicked', () => {
+    const { getByTestId } = render(
+      <AccordionTabs tabList={tabList} tabsProps={tabsProps} accordionProps={accordionProps} />
+    )
+
+    // Assert that the first tab is initially selected
+    expect(screen.getByRole('tab', { name: 'Tab 1' })).toBeInTheDocument()
+
+    // Click the second tab
+    userEvent.click(screen.getByRole('tab', { name: 'Tab 2' }))
+    // Assert that onChangeMock was called with the correct tab id
+    expect(tabsProps.onChange.mock.calls[0][0]).toEqual('panel-2')
+
+    // Assert that the second tab is now selected
+    expect(screen.getByRole('tab', { name: 'Tab 2' })).toBeInTheDocument()
+
+    expect(getByTestId('panel-1-details')).toBeDefined()
+    expect(() => getByTestId('panel-2-details')).toThrow()
+
+    expect(getByTestId('panel-1-panel').dataset.open).toBe('true')
+    expect(getByTestId('panel-2-panel').dataset.open).toBe('false')
+    fireEvent.click(getByTestId('panel-2-summary'))
+    expect(accordionProps.onChange).toHaveBeenCalledWith('panel-2')
+  })
+})

--- a/packages/uicore/src/components/AccordionTabs/AccordionTabs.tsx
+++ b/packages/uicore/src/components/AccordionTabs/AccordionTabs.tsx
@@ -19,7 +19,10 @@ export interface TabListProps extends Omit<ITabProps, 'id' | 'title'> {
 export interface AccordionTabsProps {
   tabList: TabListProps[]
   tabsProps: TabsProps
-  accordionProps: Omit<AccordionProps, 'children'>
+  accordionProps: Omit<AccordionProps, 'children'> & {
+    /** The controlled active ID for the Accordion. Must be provided for synchronization with Tabs. */
+    controlledActiveId: string
+  }
 }
 
 const AccordionTabs: React.FC<AccordionTabsProps> = ({ tabList, tabsProps, accordionProps, children }) => {

--- a/packages/uicore/src/components/AccordionTabs/AccordionTabs.tsx
+++ b/packages/uicore/src/components/AccordionTabs/AccordionTabs.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { ITabProps, Tab } from '@blueprintjs/core'
+import { Accordion, AccordionProps } from '../Accordion/Accordion'
+import { Tabs, TabsProps } from '../Tabs/Tabs'
+import React from 'react'
+
+export interface TabListProps extends Omit<ITabProps, 'id' | 'title'> {
+  id: string
+  title: React.ReactNode
+  dataTestId?: string
+}
+
+export interface AccordionTabsProps {
+  tabList: TabListProps[]
+  tabsProps: TabsProps
+  accordionProps: Omit<AccordionProps, 'children'>
+}
+
+const AccordionTabs: React.FC<AccordionTabsProps> = ({ tabList, tabsProps, accordionProps, children }) => {
+  const accordionChildren = tabList.map(tabItem => (
+    <Accordion.Panel
+      key={tabItem.id}
+      id={tabItem.id}
+      summary={tabItem.title}
+      details={tabItem.panel}
+      data-testid={tabItem.dataTestId}
+      disabled={tabItem.disabled}
+    />
+  ))
+
+  return (
+    <>
+      <Tabs {...tabsProps}>
+        {tabList.map(tabItem => (
+          <Tab
+            key={tabItem.id}
+            id={tabItem.id}
+            title={tabItem.title}
+            disabled={tabItem.disabled}
+            className={tabItem.className}
+            panelClassName={tabItem.panelClassName}
+          />
+        ))}
+      </Tabs>
+      {children}
+      <Accordion {...accordionProps}>
+        {/* Rendering the Accordion.Panel components through tablist */}
+        {accordionChildren}
+      </Accordion>
+    </>
+  )
+}
+
+export { AccordionTabs }

--- a/packages/uicore/src/index.ts
+++ b/packages/uicore/src/index.ts
@@ -14,6 +14,7 @@ export {
   useNestedAccordion,
   NestedAccordionContextData
 } from './components/Accordion/NestedAccordion'
+export { AccordionTabsProps, TabListProps, AccordionTabs } from './components/AccordionTabs/AccordionTabs'
 export { Avatar, AvatarProps, AvatarSizes } from './components/Avatar/Avatar'
 export { getInitialsFromNameOrEmail } from './components/Avatar/utils'
 export { AvatarGroup, AvatarGroupProps } from './components/AvatarGroup/AvatarGroup'


### PR DESCRIPTION
- Added controlledActiveId support for Accordion which allows accordion panels to be driven by controlledActiveId which can be changed via onChange
- Added AccordionTab component which renders horizontal Tabs with vertical Accordion.Panel corresponding to each Tab


https://github.com/harness/uicore/assets/100121280/803300f3-af64-409f-8d31-0bdfdc5cb530



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
