### PR TITLE
fix: [CI-8191]: Revert background css to fix version bump issue

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/design-system",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Harness Help panel - used for building Help panels generated through contentful",
   "source": "src/index.ts",
   "main": "./dist/design-system.umd.js",

--- a/packages/design-system/src/styled-props/background.css
+++ b/packages/design-system/src/styled-props/background.css
@@ -62,10 +62,6 @@
     background: var(--grey-100);
   }
 
-  &.background-grey50 {
-    background: var(--grey-50);
-  }
-
   &.background-blue900 {
     background: var(--blue-900);
   }
@@ -200,10 +196,6 @@
 
   &.background-yellow100 {
     background: var(--yellow-100);
-  }
-
-  &.background-yellow50 {
-    background: var(--yellow-50);
   }
 
   &.background-green800 {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

Reverting few changes from https://github.com/harness/uicore/pull/742 to avoid unintentional snapshot updates in https://github.com/harness/harness-core-ui/pull/16175 due to version bump `1.0.0` -> `1.5.1`

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
