### PR TITLE
feat: [CHAOS-1910]: Add support for user defined watermark icon in StepWizard

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.143.0",
+  "version": "3.144.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/StepWizard/StepWizard.tsx
+++ b/packages/uicore/src/components/StepWizard/StepWizard.tsx
@@ -34,6 +34,7 @@ export type GotoStepArgs<SharedObject> =
 export interface StepWizardProps<SharedObject> {
   icon?: IconName
   iconProps?: Omit<IconProps, 'name'>
+  watermarkIcon?: IconName
   title?: string | JSX.Element
   subtitle?: string | JSX.Element
   children:
@@ -124,6 +125,7 @@ export function StepWizard<SharedObject = Record<string, unknown>>(
     navClassName = '',
     icon = '',
     iconProps,
+    watermarkIcon = 'harness-with-color',
     title = '',
     subtitle = ''
   } = props
@@ -397,7 +399,7 @@ export function StepWizard<SharedObject = Record<string, unknown>>(
       {state.activeStep && (
         <div className={cx(css.stepDetails, stepClassName)}> {React.cloneElement(activeChild, childProps)}</div>
       )}
-      <Icon name="harness-with-color" className={css.harnessWatermark} size={346} color={Color.GREY_50} />
+      <Icon name={watermarkIcon} className={css.harnessWatermark} size={346} color={Color.GREY_50} />
     </div>
   )
 }


### PR DESCRIPTION

Added support for user defined watermark icon in StepWizard. Since Litmus 3.0 beta utilises ui-core library, we need a prop to pass custom icons for watermark. 
It has been added as an optional prop that defaults to `harness-with-color` icon.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
