### PR TITLE
feat: SSCA-269 update button click return type to work with RQ refetch

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.144.0",
+  "version": "3.145.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Button/Button.tsx
+++ b/packages/uicore/src/components/Button/Button.tsx
@@ -53,7 +53,7 @@ export interface ButtonProps
   withoutBoxShadow?: boolean
 
   /** onClick event handler */
-  onClick?: (event: MouseEvent) => Promise<void> | void
+  onClick?: (event: MouseEvent) => Promise<unknown> | void
 
   /** Link href. If provided, Button rendered as Link */
   href?: string


### PR DESCRIPTION
ReactQuery refetch returns Promise<DataType> but not Promise<void>

```
const {isLoading, refetch} = Query(...)

<Button onClick={() => refetch()} loading={isLoading} />

