### PR TITLE
fix: [CDS-73038]: getMultiType return expression type even if the allowed types doesn't contain expression

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.145.0",
+  "version": "3.145.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -97,7 +97,14 @@ export const getMultiTypeFromValue = (
     if (isValueAnExpression(value)) return MultiTypeInputType.EXPRESSION
   } else if (Array.isArray(value) && supportListOfExpressionsBehaviour) {
     // To support list of expressions
-    if (value.some((item: string | MultiSelectOption) => typeof item === 'string' && isValueAnExpression(item)))
+    if (
+      value.some(
+        (item: string | MultiSelectOption) =>
+          typeof item === 'string' &&
+          isValueAnExpression(item) &&
+          allowableTypes?.includes(MultiTypeInputType.EXPRESSION)
+      )
+    )
       return MultiTypeInputType.EXPRESSION
   }
   if (!value && allowableTypes?.length) {


### PR DESCRIPTION
- `getMultiTypeFromValue` return expression type even if the allowed types doesn't contain expression type


https://github.com/harness/uicore/assets/106532291/79039915-8cdc-4070-9c78-41e4c7a8a63a



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
