### PR TITLE
feat: [PL-40071]: Removing lineclamp from contentText in confirmation dialog

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.146.0",
+  "version": "3.146.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.css
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.css
@@ -19,5 +19,6 @@
   }
   .body {
     flex: 1;
+    word-wrap: break-word;
   }
 }

--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -92,7 +92,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
         color={Color.BLACK}
         margin={{ top: 'large', bottom: 'xxlarge' }}
         className={css.body}>
-        <Text lineClamp={5}>{contentText}</Text>
+        {contentText}
       </Layout.Vertical>
       {children}
       <Layout.Horizontal spacing="small">


### PR DESCRIPTION
**Issue** - lineClamp property on contentText in ConfirmationDialog was causing text breaking issue across all the confirmation dialog's through out the Harness app. There were multiple issues raised recently for different dialog's. 

**fix** - Removed the line-clamp and added break-word property, line-clamp should be added by child component instead of the common component. ConfirmationDialog shouldn't restrict the content text to be not more than 5 lines. 
Also, the type of contentText is ReactNode, wrapping it in `<Text>` doesn't make sense. 


Issues raised recently - 

https://harness.atlassian.net/browse/PL-40071
https://harness.atlassian.net/browse/PL-40070

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
