### PR TITLE
feat: [CDS-73647]: add right Icon support for select label

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.146.1",
+  "version": "3.147.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Select/BiLevelSelect.tsx
+++ b/packages/uicore/src/components/Select/BiLevelSelect.tsx
@@ -33,9 +33,6 @@ export interface SelectWithBiLevelOption {
   /** right icon to render in defaultItemRenderer */
   rightIcon?: IconProps
 
-  /** custom className for right icon to render in defaultItemRenderer */
-  rightIconClassName?: string
-
   /** list of all subitems */
   submenuItems?: SelectWithBiLevelOption[]
 }

--- a/packages/uicore/src/components/Select/BiLevelSelect.tsx
+++ b/packages/uicore/src/components/Select/BiLevelSelect.tsx
@@ -30,6 +30,12 @@ export interface SelectWithBiLevelOption {
   /** icon to render in defaultItemRenderer */
   icon?: IconProps
 
+  /** right icon to render in defaultItemRenderer */
+  rightIcon?: IconProps
+
+  /** custom className for right icon to render in defaultItemRenderer */
+  rightIconClassName?: string
+
   /** list of all subitems */
   submenuItems?: SelectWithBiLevelOption[]
 }

--- a/packages/uicore/src/components/Select/Select.css
+++ b/packages/uicore/src/components/Select/Select.css
@@ -159,6 +159,9 @@
       color: var(--grey-400);
       cursor: not-allowed;
     }
+    &.rightIcon {
+      justify-content: space-between;
+    }
 
     &:hover {
       background: var(--primary-1);

--- a/packages/uicore/src/components/Select/Select.stories.tsx
+++ b/packages/uicore/src/components/Select/Select.stories.tsx
@@ -52,7 +52,7 @@ export const Basic: Story<SelectProps> = args => {
 Basic.args = {
   size: SelectSize.Medium,
   items: [
-    { label: 'Kubernetes', value: 'service-kubernetes', rightIcon: { name: 'Account', size: 10 } },
+    { label: 'Kubernetes', value: 'service-kubernetes' },
     { label: 'GitHub', value: 'service-github' },
     { label: 'ELK', value: 'service-elk' },
     { label: 'Jenkins', value: 'service-jenkins' },

--- a/packages/uicore/src/components/Select/Select.stories.tsx
+++ b/packages/uicore/src/components/Select/Select.stories.tsx
@@ -52,7 +52,7 @@ export const Basic: Story<SelectProps> = args => {
 Basic.args = {
   size: SelectSize.Medium,
   items: [
-    { label: 'Kubernetes', value: 'service-kubernetes' },
+    { label: 'Kubernetes', value: 'service-kubernetes', rightIcon: { name: 'Account', size: 10 } },
     { label: 'GitHub', value: 'service-github' },
     { label: 'ELK', value: 'service-elk' },
     { label: 'Jenkins', value: 'service-jenkins' },

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -21,6 +21,8 @@ export interface SelectOption {
   label: string
   value: string | number | symbol
   icon?: IconProps
+  rightIcon?: IconProps
+  rightIconClassName?: string
 }
 
 export enum SelectSize {
@@ -101,13 +103,17 @@ export function defaultItemRenderer(
           [css.disabled]: props.modifiers.disabled
         },
         { [css.menuItemSizeSmall]: size === SelectSize.Small },
-        { [css.menuItemSizeLarge]: size === SelectSize.Large }
+        { [css.menuItemSizeLarge]: size === SelectSize.Large },
+        { [css.rightIcon]: item.rightIcon }
       )}
       onClick={props.handleClick}>
       {item.icon ? <Icon size={getIconSizeFromSelect(size)} {...item.icon} /> : null}
       <Text className={css.menuItemLabel} lineClamp={1}>
         {item.label}
       </Text>
+      {item.rightIcon ? (
+        <Icon className={item.rightIconClassName} size={getIconSizeFromSelect(size)} {...item.rightIcon} />
+      ) : null}
     </li>
   )
 }

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -22,7 +22,6 @@ export interface SelectOption {
   value: string | number | symbol
   icon?: IconProps
   rightIcon?: IconProps
-  rightIconClassName?: string
 }
 
 export enum SelectSize {
@@ -111,9 +110,7 @@ export function defaultItemRenderer(
       <Text className={css.menuItemLabel} lineClamp={1}>
         {item.label}
       </Text>
-      {item.rightIcon ? (
-        <Icon className={item.rightIconClassName} size={getIconSizeFromSelect(size)} {...item.rightIcon} />
-      ) : null}
+      {item.rightIcon ? <Icon size={getIconSizeFromSelect(size)} {...item.rightIcon} /> : null}
     </li>
   )
 }


### PR DESCRIPTION
- Add right icon to the select option dropdown



https://github.com/harness/uicore/assets/106532291/f7c9a676-31c9-4ce7-8eab-2fa6c8c83a1d


<img width="1726" alt="Screenshot 2023-07-20 at 4 47 23 PM" src="https://github.com/harness/uicore/assets/106532291/705dc6a0-0e3c-469c-907e-af6559af684c">






You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
