### PR TITLE
fix: [CDS-75164]: trimmed searchterms for expandingSearchInputs

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.147.0",
+  "version": "3.148.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ExpandingSearchInput/ExpandingSearchInput.tsx
+++ b/packages/uicore/src/components/ExpandingSearchInput/ExpandingSearchInput.tsx
@@ -114,7 +114,7 @@ export function ExpandingSearchInput(
       const text = event.target.value
       setValue(text)
       timerRef.current = setTimeout(() => {
-        propsOnChange?.(text)
+        propsOnChange?.(text?.trim())
       }, throttle)
     },
     [setValue, propsOnChange, throttle]


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
