### PR TITLE
fix: [CDS-75452]: suppress onInteraction warning + optimise ExpressionDropdown ( Resize Observer limit reacher Error )

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.0",
+  "version": "3.148.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ExpressionDropdown/ExpressionDropdown.tsx
+++ b/packages/uicore/src/components/ExpressionDropdown/ExpressionDropdown.tsx
@@ -58,13 +58,12 @@ export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.El
     return listItems
   }, [rootTrieNode, query])
 
-  const dropDownItemClickHandler = React.useCallback(
-    (value: string): void => {
-      const valueBefore = query.substring(0, query.lastIndexOf('<'))
-      setQueryValue(`${valueBefore}<+${value}`)
-    },
-    [query]
-  )
+  const dropDownItemClickHandler = React.useCallback((value: string): void => {
+    setQueryValue(prevQuery => {
+      const valueBefore = prevQuery.substring(0, prevQuery.lastIndexOf('<'))
+      return `${valueBefore}<+${value}`
+    })
+  }, [])
 
   const itemClickHandler = React.useCallback(
     (valueTillHere: string, isOverflow = false): void => {

--- a/packages/uicore/src/components/ExpressionDropdown/ExpressionDropdown.tsx
+++ b/packages/uicore/src/components/ExpressionDropdown/ExpressionDropdown.tsx
@@ -33,117 +33,13 @@ interface NewExpressionDropdownProps {
   itemRenderer: React.ReactNode
 }
 
-interface getVisibleItemRendererProps {
-  dropDownItemClickHandler: (value: string) => void
-  isOpen: boolean[]
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean[]>>
-}
-
-function getOverflowRenderer(props: getVisibleItemRendererProps): any {
-  const { dropDownItemClickHandler, isOpen, setIsOpen } = props
-
-  const [isPopoverOpen, setIsPopoverOpen] = React.useState<boolean>(false)
-
-  // eslint-disable-next-line react/display-name
-  return (items: TrieNode[]): JSX.Element => {
-    function itemClickHandler(valueTillHere: string): void {
-      setIsPopoverOpen(!isPopoverOpen)
-      setOpenTargetElement(isOpen, setIsOpen, valueTillHere, true)
-    }
-
-    return (
-      <Layout.Horizontal>
-        <Popover isOpen={isPopoverOpen} minimal>
-          <Layout.Horizontal className={css.visibleItemText} onClick={() => itemClickHandler(items[0].valueTillHere)}>
-            <div className={css.visibleItemTextHeader}>{items[0].value}</div>
-            <Icon name={getDropDownIcon(items[0], isOpen)} padding={{ left: '5px', right: '10px' }} size={10} />
-          </Layout.Horizontal>
-          <Menu>
-            {items[0].children.map(
-              (child, ind) =>
-                child.children.length !== 0 && (
-                  <Menu.Item
-                    key={`${ind} ${child.value}`}
-                    onClick={() => {
-                      dropDownItemClickHandler(child.valueTillHere)
-                      setOpenTargetElement(isOpen, setIsOpen, items[0].valueTillHere, false)
-                    }}
-                    text={child.value}
-                  />
-                )
-            )}
-          </Menu>
-        </Popover>
-        {items.length > 1 ? (
-          <Popover minimal>
-            <div style={{ cursor: 'pointer' }}>...</div>
-            <Menu>
-              {items.map((item, index) => {
-                if (index !== 0) {
-                  return (
-                    <Menu.Item
-                      key={index}
-                      text={item.value}
-                      onClick={() => dropDownItemClickHandler(item.valueTillHere)}
-                    />
-                  )
-                }
-              })}
-            </Menu>
-          </Popover>
-        ) : null}
-      </Layout.Horizontal>
-    )
-  }
-}
-
-function getVisibleItemRenderer(props: getVisibleItemRendererProps): any {
-  const { dropDownItemClickHandler, isOpen, setIsOpen } = props
-
-  // eslint-disable-next-line react/display-name
-  return (item: TrieNode, index: number): JSX.Element => {
-    function itemClickHandler(valueTillHere: string): void {
-      setOpenTargetElement(isOpen, setIsOpen, valueTillHere, true)
-    }
-
-    // return the visible item JSX from here
-
-    const shallShowNesting = item.children.some(child => child.children.length !== 0)
-
-    return (
-      <Popover key={index} minimal>
-        <Layout.Horizontal className={css.visibleItemText} onClick={() => itemClickHandler(item.valueTillHere)}>
-          <div className={css.visibleItemTextHeader}>{item.value}</div>
-          {shallShowNesting && <Icon name={getDropDownIcon(item, isOpen)} className={css.paddingLeft} size={10} />}
-        </Layout.Horizontal>
-        <Menu>
-          {item.children.map(
-            (child, ind) =>
-              child.children.length !== 0 && (
-                <Menu.Item
-                  key={`${ind} ${child.value}`}
-                  onClick={() => {
-                    dropDownItemClickHandler(child.valueTillHere)
-                    setOpenTargetElement(isOpen, setIsOpen, item.valueTillHere, false)
-                  }}
-                  text={child.value}
-                />
-              )
-          )}
-        </Menu>
-      </Popover>
-    )
-  }
-}
-
 export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.Element => {
   const { rootTrieNode, query = '', itemRenderer, setQueryValue } = props
 
-  const [overflowListItems, setOverflowListItems] = useState<TrieNode[]>([])
-
   const [isOpen, setIsOpen] = useState<boolean[]>([])
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState<boolean>(false)
 
-  React.useEffect(() => {
+  const overflowListItems = React.useMemo(() => {
     // set list items here and get the correct currentTrieNode
     let currentNode: TrieNode | undefined = rootTrieNode
     const listItems: TrieNode[] = [currentNode]
@@ -159,18 +55,112 @@ export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.El
         currentNode = undefined
       }
     })
-
-    setOverflowListItems(listItems)
-  }, [query])
+    return listItems
+  }, [rootTrieNode, query])
 
   const dropDownItemClickHandler = (value: string): void => {
     const valueBefore = query.substring(0, query.lastIndexOf('<'))
     setQueryValue(`${valueBefore}<+${value}`)
   }
 
-  const visibleItemRenderer = getVisibleItemRenderer({ dropDownItemClickHandler, isOpen, setIsOpen })
+  const itemClickHandler = React.useCallback(
+    (valueTillHere: string, isOverflow = false): void => {
+      setOpenTargetElement(isOpen, setIsOpen, valueTillHere, true)
+      isOverflow && setIsPopoverOpen(prevState => !prevState)
+    },
+    [isOpen, setIsOpen]
+  )
 
-  const overflowListRenderer = getOverflowRenderer({ dropDownItemClickHandler, isOpen, setIsOpen })
+  const shallShowNesting = (item: TrieNode) => item.children.some(child => child.children.length !== 0)
+
+  const visibleItemRenderer = React.useMemo(() => {
+    // eslint-disable-next-line react/display-name
+    return (item: TrieNode, index: number): JSX.Element => {
+      const clickHandler = () => itemClickHandler(item.valueTillHere)
+
+      // return the visible item JSX from here
+      const content = (
+        <Layout.Horizontal className={css.visibleItemText} onClick={clickHandler}>
+          <div className={css.visibleItemTextHeader}>{item.value}</div>
+          {shallShowNesting(item) && (
+            <Icon name={getDropDownIcon(item, isOpen)} className={css.paddingLeft} size={10} />
+          )}
+        </Layout.Horizontal>
+      )
+
+      return (
+        <Popover key={index} minimal>
+          {content}
+          <Menu>
+            {item.children.map(
+              (child, ind) =>
+                child.children.length !== 0 && (
+                  <Menu.Item
+                    key={`${ind} ${child.value}`}
+                    onClick={() => {
+                      dropDownItemClickHandler(child.valueTillHere)
+                      setOpenTargetElement(isOpen, setIsOpen, item.valueTillHere, false)
+                    }}
+                    text={child.value}
+                  />
+                )
+            )}
+          </Menu>
+        </Popover>
+      )
+    }
+  }, [dropDownItemClickHandler, isOpen, setIsOpen])
+
+  const overflowListRenderer = React.useMemo(() => {
+    // eslint-disable-next-line react/display-name
+    return (items: TrieNode[]): JSX.Element => {
+      const clickHandler = () => itemClickHandler(items[0].valueTillHere, true)
+
+      return (
+        <Layout.Horizontal>
+          <Popover isOpen={isPopoverOpen} minimal>
+            <Layout.Horizontal className={css.visibleItemText} onClick={clickHandler}>
+              <div className={css.visibleItemTextHeader}>{items[0].value}</div>
+              <Icon name={getDropDownIcon(items[0], isOpen)} padding={{ left: '5px', right: '10px' }} size={10} />
+            </Layout.Horizontal>
+            <Menu>
+              {items[0].children.map(
+                (child, ind) =>
+                  child.children.length !== 0 && (
+                    <Menu.Item
+                      key={`${ind} ${child.value}`}
+                      onClick={() => {
+                        dropDownItemClickHandler(child.valueTillHere)
+                        setOpenTargetElement(isOpen, setIsOpen, items[0].valueTillHere, false)
+                      }}
+                      text={child.value}
+                    />
+                  )
+              )}
+            </Menu>
+          </Popover>
+          {items.length > 1 ? (
+            <Popover minimal>
+              <div style={{ cursor: 'pointer' }}>...</div>
+              <Menu>
+                {items.map((item, index) => {
+                  if (index !== 0) {
+                    return (
+                      <Menu.Item
+                        key={index}
+                        text={item.value}
+                        onClick={() => dropDownItemClickHandler(item.valueTillHere)}
+                      />
+                    )
+                  }
+                })}
+              </Menu>
+            </Popover>
+          ) : null}
+        </Layout.Horizontal>
+      )
+    }
+  }, [dropDownItemClickHandler, isOpen, setIsOpen])
 
   const queryValue = query.substring(query.lastIndexOf('+') + 1)
 

--- a/packages/uicore/src/components/ExpressionDropdown/ExpressionDropdown.tsx
+++ b/packages/uicore/src/components/ExpressionDropdown/ExpressionDropdown.tsx
@@ -58,10 +58,13 @@ export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.El
     return listItems
   }, [rootTrieNode, query])
 
-  const dropDownItemClickHandler = (value: string): void => {
-    const valueBefore = query.substring(0, query.lastIndexOf('<'))
-    setQueryValue(`${valueBefore}<+${value}`)
-  }
+  const dropDownItemClickHandler = React.useCallback(
+    (value: string): void => {
+      const valueBefore = query.substring(0, query.lastIndexOf('<'))
+      setQueryValue(`${valueBefore}<+${value}`)
+    },
+    [query]
+  )
 
   const itemClickHandler = React.useCallback(
     (valueTillHere: string, isOverflow = false): void => {
@@ -71,18 +74,17 @@ export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.El
     [isOpen, setIsOpen]
   )
 
-  const shallShowNesting = (item: TrieNode) => item.children.some(child => child.children.length !== 0)
+  const showDropdownIcon = (item: TrieNode) => item.children.some(child => child.children.length !== 0)
 
   const visibleItemRenderer = React.useMemo(() => {
-    // eslint-disable-next-line react/display-name
-    return (item: TrieNode, index: number): JSX.Element => {
+    const VisibleItem = (item: TrieNode, index: number): JSX.Element => {
       const clickHandler = () => itemClickHandler(item.valueTillHere)
 
       // return the visible item JSX from here
       const content = (
         <Layout.Horizontal className={css.visibleItemText} onClick={clickHandler}>
           <div className={css.visibleItemTextHeader}>{item.value}</div>
-          {shallShowNesting(item) && (
+          {showDropdownIcon(item) && (
             <Icon name={getDropDownIcon(item, isOpen)} className={css.paddingLeft} size={10} />
           )}
         </Layout.Horizontal>
@@ -109,11 +111,11 @@ export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.El
         </Popover>
       )
     }
+    return VisibleItem
   }, [dropDownItemClickHandler, isOpen, setIsOpen])
 
   const overflowListRenderer = React.useMemo(() => {
-    // eslint-disable-next-line react/display-name
-    return (items: TrieNode[]): JSX.Element => {
+    const OverflowList = (items: TrieNode[]): JSX.Element => {
       const clickHandler = () => itemClickHandler(items[0].valueTillHere, true)
 
       return (
@@ -160,6 +162,8 @@ export const NewExpressionDropdown = (props: NewExpressionDropdownProps): JSX.El
         </Layout.Horizontal>
       )
     }
+
+    return OverflowList
   }, [dropDownItemClickHandler, isOpen, setIsOpen])
 
   const queryValue = query.substring(query.lastIndexOf('+') + 1)

--- a/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
+++ b/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
@@ -209,9 +209,10 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
               })
 
               const child = inputRef.current.childNodes[childIndex]
-              const offset = childNodesTextLength[childIndex - 1] - position + 2
-
-              setCaret(child, offset)
+              if (child.nodeType === Node.ELEMENT_NODE) {
+                const offset = childNodesTextLength[childIndex - 1] - position + 2
+                setCaret(child, offset)
+              }
             } else {
               // position is sum of firstHalf.length + 2 (for '<+') + item.length + 1 (for '>')
               const position = firstHalf.length + 2 + item.length + 1

--- a/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
+++ b/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
@@ -209,7 +209,7 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
               })
 
               const child = inputRef.current.childNodes[childIndex]
-              if (child.nodeType === Node.ELEMENT_NODE) {
+              if (child?.nodeType === Node.ELEMENT_NODE) {
                 const offset = childNodesTextLength[childIndex - 1] - position + 2
                 setCaret(child, offset)
               }

--- a/packages/uicore/src/frameworks/Tooltip/Tooltip.tsx
+++ b/packages/uicore/src/frameworks/Tooltip/Tooltip.tsx
@@ -50,10 +50,6 @@ export const HarnessDocTooltip = ({
       popoverClassName={css.tooltipWrapper}
       position="auto"
       interactionKind={PopoverInteractionKind.HOVER}
-      onInteraction={(_, e) => {
-        e?.preventDefault()
-        e?.nativeEvent.stopImmediatePropagation()
-      }}
       content={
         <div
           className={css.tooltipContentWrapper}


### PR DESCRIPTION
Jira: https://harness.atlassian.net/browse/CDS-75452

Error: **ResizeObserver loop completed with undelivered notifications.**

**Summary:**
Since many stack trace point to expression component and few instances of stack-trace referencing to https://widget.saberfeedback.com/v2/widget.js:1:63953 createSaberObject/window.Saber</event_log</window.onerror. 
The underlying issue can be due to unnecessary re-renders or some event bubbling to blueprintJS components triggering ResizeObserver API being consumed by Popovers, Menu etc. components from blueprintJS.
There were multiple warning related to `[Blueprint] <Popover> onInteraction is ignored when uncontrolled.` which can be the potential root cause for the error .

**Fix:**
- Avoid unnecessary re-renders for Expression Dropdown component
- Fixes `[Blueprint] <Popover> onInteraction is ignored when uncontrolled.` warning from tooltip component 
- Added safe check for `Failed to execute 'setStart' on 'Range': parameter 1 is not of type 'Node'.` error when element in setCaret is not of type `Node`

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
