### PR TITLE
fix: [CDS-74650]: allowed onChange to override from the caller via props for KVTagInput

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.1",
+  "version": "3.148.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -144,6 +144,7 @@ export interface KVTagInputProps extends Omit<IFormGroupProps, 'labelFor' | 'ite
   name: string
   tagsProps?: Partial<ITagInputProps>
   isArray?: boolean
+  onChange?: ITagInputProps['onChange']
 }
 
 type KVAccumulator = { [key: string]: string }
@@ -194,6 +195,7 @@ function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
                   return acc
                 }, {} as KVAccumulator) || {}
           )
+          props.onChange?.(values)
         }}
         inputRef={input => {
           input?.setAttribute('data-mentions', mentionsType)


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
