### PR TITLE
fix: [CDS-76216]: set default value of defaultValueToReset as empty string in ExpressionAndRuntimeType component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.2",
+  "version": "3.148.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/__tests__/FormikForm.test.tsx
+++ b/packages/uicore/src/components/FormikForm/__tests__/FormikForm.test.tsx
@@ -470,4 +470,45 @@ describe('Test basic Components', () => {
     })
     expect(input).toHaveDisplayValue('value')
   })
+
+  test('switching to expression from fixed type for MultiTypeInput component should call onChange with value as empty string', async () => {
+    const mockedOnChangeFunc = jest.fn()
+    render(
+      renderFormikForm(
+        <FormInput.MultiTypeInput
+          name="dropdown"
+          label="Dropdown Field"
+          placeholder="enter value"
+          selectItems={[
+            {
+              label: 'Field 1',
+              value: 'Field_1'
+            },
+            {
+              label: 'Field 2',
+              value: 'Field_2'
+            }
+          ]}
+          useValue={true}
+          multiTypeInputProps={{
+            onChange: mockedOnChangeFunc
+          }}
+        />
+      )
+    )
+
+    const input = screen.getByPlaceholderText('enter value')
+    expect(input).toBeInTheDocument()
+
+    const multiTypeButton = screen.getByTestId('multi-type-button')
+    expect(multiTypeButton).toBeInTheDocument()
+    userEvent.click(multiTypeButton as HTMLButtonElement)
+
+    const expressionOption = await screen.findByText(/expression/i)
+    userEvent.click(expressionOption)
+
+    await waitFor(() => {
+      expect(mockedOnChangeFunc).toHaveBeenLastCalledWith('', MultiTypeInputValue.STRING, MultiTypeInputType.EXPRESSION)
+    })
+  })
 })

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -116,7 +116,7 @@ export const getMultiTypeFromValue = (
 export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntimeTypeProps<T>): React.ReactElement {
   const {
     value,
-    defaultValueToReset,
+    defaultValueToReset = '',
     width,
     expressions = [],
     onTypeChange,


### PR DESCRIPTION
**Summary:**

Without this fix, whichever consumer does not send defaultValueToReset as empty string to MultiTypeInput component will cause page crash, if tried to access value out of selected item without adding null check before that.

So, handled it generically in this common component add set empty string as default value for the prop.

Jira: https://harness.atlassian.net/browse/CDS-76216


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
