### PR TITLE
fix: [CDS-76354]: closing tag being added at wrong cursor position

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.3",
+  "version": "3.148.4",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
+++ b/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
@@ -209,7 +209,7 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
               })
 
               const child = inputRef.current.childNodes[childIndex]
-              if (child?.nodeType === Node.ELEMENT_NODE) {
+              if (child?.nodeType === Node.ELEMENT_NODE || child?.nodeType === Node.TEXT_NODE) {
                 const offset = childNodesTextLength[childIndex - 1] - position + 2
                 setCaret(child, offset)
               }

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -105,7 +105,7 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
 
     if (e.key === '>' && this.props.inputRef.current) {
       e.preventDefault()
-      const index = getCaretIndex(e.target) + 2
+      const index = getCaretIndex(e.target)
 
       const newStr =
         (textContent.slice(0, index) as string) +
@@ -118,17 +118,16 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
       const childNodesTextLength = createChildNodeLengthSumArray(this.props.inputRef.current.childNodes)
 
       const childIndex = childNodesTextLength.findIndex(i => {
-        return i >= index
+        return i >= index + 1
       })
 
       const child = this.props.inputRef.current.childNodes[childIndex]
-      const offset = childNodesTextLength[childIndex] - index + 1
-
-      setCaret(child, offset)
+      const offset = childNodesTextLength[childIndex] - index
 
       this.props.onInput(e)
+      setCaret(child, offset)
+      this.props.keyDown(e)
     }
-    this.props.keyDown(e)
   }
 
   render() {

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -126,8 +126,8 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
 
       this.props.onInput(e)
       setCaret(child, offset)
-      this.props.keyDown(e)
     }
+    this.props.keyDown(e)
   }
 
   render() {


### PR DESCRIPTION


https://github.com/harness/uicore/assets/106532291/9fb0c2f2-610c-4a3d-ba02-27bb3b61c428



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
