### PR TITLE
fix: handle the sanitize for text elements

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.4",
+  "version": "3.148.5",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -78,6 +78,7 @@ export function getCaretIndex(element: HTMLElement): number {
 
 export function setCaret(element: ChildNode, index: number, isCompleteElement?: boolean): void {
   const range = document.createRange()
+  // DOM treats the nested element's text (isCompleteElement) as a single entity so range cannot be handled with offset length
   if (isCompleteElement) {
     range.setStartAfter(element)
   } else {
@@ -151,6 +152,10 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
       }
 
       this.props.onInput(e)
+      /**
+       * node.nodeName returns #text for an exclusive Text node
+       *  MDN Reference :- https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
+       */
       setCaret(child, offset, child.nodeName.toLowerCase() !== '#text')
     }
     this.props.keyDown(e)

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -76,9 +76,13 @@ export function getCaretIndex(element: HTMLElement): number {
   return position
 }
 
-export function setCaret(element: ChildNode, index: number): void {
+export function setCaret(element: ChildNode, index: number, isCompleteElement?: boolean): void {
   const range = document.createRange()
-  range.setStart(element, index)
+  if (isCompleteElement) {
+    range.setStartAfter(element)
+  } else {
+    range.setStart(element, index)
+  }
   range.collapse(true)
 
   const sel = window.getSelection() as any
@@ -145,8 +149,9 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
       } else {
         offset = index + 1
       }
+
       this.props.onInput(e)
-      setCaret(child, offset)
+      setCaret(child, offset, child.nodeName.toLowerCase() !== '#text')
     }
     this.props.keyDown(e)
   }

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -134,12 +134,17 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
       const childNodesTextLength = createChildNodeLengthSumArray(this.props.inputRef.current.childNodes)
 
       const childIndex = childNodesTextLength.findIndex(i => {
-        return i >= index + 1
+        return i >= index
       })
 
       const child = this.props.inputRef.current.childNodes[childIndex]
-      const offset = childNodesTextLength[childIndex] - index
-
+      const prevChild = this.props.inputRef.current.childNodes[childIndex - 1]
+      let offset = 0
+      if (prevChild) {
+        offset = index - childNodesTextLength[childIndex - 1] + 1
+      } else {
+        offset = index + 1
+      }
       this.props.onInput(e)
       setCaret(child, offset)
     }

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -12,6 +12,22 @@ import css from './TextAreaEditable.css'
 
 const VAR_REGEX = /(<\+[a-zA-z0-9_.]+?>)/
 
+function sanitizeHTML(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\u00a0/g, ' ')
+}
+
+function sanitizerForTextElements(input: TextObject[]): TextObject[] {
+  return input.map(item => {
+    if (item.type === 'text') {
+      return { type: item.type, text: sanitizeHTML(item.text) }
+    } else return item
+  })
+}
+
 function deserialize(input: string): TextObject[] {
   const split = input.split(VAR_REGEX)
 
@@ -113,7 +129,7 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
         (textContent.slice(index).trimEnd() as string) +
         ' '
 
-      this.props.inputRef.current.innerHTML = highlight(deserialize(newStr))
+      this.props.inputRef.current.innerHTML = highlight(sanitizerForTextElements(deserialize(newStr)))
 
       const childNodesTextLength = createChildNodeLengthSumArray(this.props.inputRef.current.childNodes)
 

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -20,7 +20,7 @@ function sanitizeHTML(str: string): string {
     .replace(/\u00a0/g, ' ')
 }
 
-function sanitizerForTextElements(input: TextObject[]): TextObject[] {
+function sanitizeHTMLTextObject(input: TextObject[]): TextObject[] {
   return input.map(item => {
     if (item.type === 'text') {
       return { type: item.type, text: sanitizeHTML(item.text) }
@@ -134,7 +134,7 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
         (textContent.slice(index).trimEnd() as string) +
         ' '
 
-      this.props.inputRef.current.innerHTML = highlight(sanitizerForTextElements(deserialize(newStr)))
+      this.props.inputRef.current.innerHTML = highlight(sanitizeHTMLTextObject(deserialize(newStr)))
 
       const childNodesTextLength = createChildNodeLengthSumArray(this.props.inputRef.current.childNodes)
 


### PR DESCRIPTION
- Handle case when adding `>` without the expression being present the text was being added as HTML Tag , sanitized the HTML in this case
- Maintained the caret position correctly for this edge case
- added extra range condition for complete (non text) nodes



https://github.com/harness/uicore/assets/106532291/3b268d10-aecc-44df-8f51-b25db0a6aeda


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
