### PR TITLE
fix: [CDS-76660]: escape newline characters for multi text input fields

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.5",
+  "version": "3.148.6",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -1456,6 +1456,9 @@ export interface FormMultiTextTypeInputProps extends Omit<IFormGroupProps, 'labe
   multiTextInputProps?: Omit<MultiTextInputProps, 'name'> /* In case you really want to customize the text input */
   disabled?: boolean
 }
+function escapeNewlines(input: string) {
+  return input.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
+}
 
 const FormMultiTextTypeInput = (props: FormMultiTextTypeInputProps & FormikContextProps<any>) => {
   const { formik, name, placeholder, multiTextInputProps, onChange, ...restProps } = props
@@ -1467,7 +1470,8 @@ const FormMultiTextTypeInput = (props: FormMultiTextTypeInputProps & FormikConte
     label,
     ...rest
   } = restProps
-  const value = get(formik?.values, name, '')
+  const _value = get(formik?.values, name, '')
+  const value = escapeNewlines(_value)
   const valueType = getMultiTypeFromValue(value)
   const customTextInputProps: Omit<IInputGroupProps & HTMLInputProps, 'onChange' | 'value'> = useMemo(
     () => ({


### PR DESCRIPTION

- Escape new line characters in multi text input field

https://github.com/harness/uicore/assets/106532291/8ada3e3b-99d4-4b6b-b749-c56f45740166



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
