### PR TITLE
fix: [CDS-76660]: handled number cases for escape new line function

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.148.6",
+  "version": "3.148.7",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -1457,7 +1457,10 @@ export interface FormMultiTextTypeInputProps extends Omit<IFormGroupProps, 'labe
   disabled?: boolean
 }
 function escapeNewlines(input: string) {
-  return input.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
+  if (typeof input === 'string') {
+    return input.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
+  }
+  return input
 }
 
 const FormMultiTextTypeInput = (props: FormMultiTextTypeInputProps & FormikContextProps<any>) => {

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -77,7 +77,7 @@ import { FormikTooltipContext } from './FormikTooltipContext'
 import { MultiTypeInputType } from '../MultiTypeInput/MultiTypeInputUtils'
 import { FormError } from '../FormError/FormError'
 import { DropDown as UiKitDropDown, DropDownProps } from '../DropDown/DropDown'
-import { errorCheck, getFormFieldLabel, FormikContextProps, FormikExtended } from './utils'
+import { errorCheck, getFormFieldLabel, FormikContextProps, FormikExtended, escapeNewlines } from './utils'
 import { DurationInput } from './DurationInput'
 import { SelectWithSubmenuOption } from '../SelectWithSubmenu/SelectWithSubmenu'
 import { SubmenuSelectOption } from '../SelectWithSubmenu/SelectWithSubmenuV2'
@@ -1455,12 +1455,6 @@ export interface FormMultiTextTypeInputProps extends Omit<IFormGroupProps, 'labe
   onChange?: MultiTextInputProps['onChange']
   multiTextInputProps?: Omit<MultiTextInputProps, 'name'> /* In case you really want to customize the text input */
   disabled?: boolean
-}
-function escapeNewlines(input: string) {
-  if (typeof input === 'string') {
-    return input.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
-  }
-  return input
 }
 
 const FormMultiTextTypeInput = (props: FormMultiTextTypeInputProps & FormikContextProps<any>) => {

--- a/packages/uicore/src/components/FormikForm/__tests__/utils.test.tsx
+++ b/packages/uicore/src/components/FormikForm/__tests__/utils.test.tsx
@@ -2,10 +2,10 @@ import { get } from 'lodash-es'
 import { escapeNewlines } from '../utils'
 
 describe('escapeNewlines Tests', () => {
-  test('escapeNewlines should return null for null input', () => {
-    const _inputValue = get(null, 'value', '')
+  test('escapeNewlines should return number without processing', () => {
+    const _inputValue = get({ name: 'formikObject', value: 3 }, 'value', '')
     const _value = escapeNewlines(_inputValue)
-    expect(_value).toBe(null)
+    expect(_value).toBe(3)
   })
   test('escapeNewlines should escape the new line characters', () => {
     const _value = escapeNewlines('a\nb')

--- a/packages/uicore/src/components/FormikForm/__tests__/utils.test.tsx
+++ b/packages/uicore/src/components/FormikForm/__tests__/utils.test.tsx
@@ -3,7 +3,7 @@ import { escapeNewlines } from '../utils'
 
 describe('escapeNewlines Tests', () => {
   test('escapeNewlines should return null for null input', () => {
-    const _inputValue = get({ name: 'formikObject' }, 'value', '')
+    const _inputValue = get(null, 'value', '')
     const _value = escapeNewlines(_inputValue)
     expect(_value).toBe(null)
   })

--- a/packages/uicore/src/components/FormikForm/__tests__/utils.test.tsx
+++ b/packages/uicore/src/components/FormikForm/__tests__/utils.test.tsx
@@ -1,0 +1,14 @@
+import { get } from 'lodash-es'
+import { escapeNewlines } from '../utils'
+
+describe('escapeNewlines Tests', () => {
+  test('escapeNewlines should return null for null input', () => {
+    const _inputValue = get({ name: 'formikObject' }, 'value', '')
+    const _value = escapeNewlines(_inputValue)
+    expect(_value).toBe(null)
+  })
+  test('escapeNewlines should escape the new line characters', () => {
+    const _value = escapeNewlines('a\nb')
+    expect(_value).toBe('a\\nb')
+  })
+})

--- a/packages/uicore/src/components/FormikForm/utils.tsx
+++ b/packages/uicore/src/components/FormikForm/utils.tsx
@@ -54,3 +54,10 @@ export const getFormFieldLabel = (
     props.tooltipProps?.dataTooltipId || (tooltipContext?.formName ? `${tooltipContext?.formName}_${fieldName}` : '')
   return <HarnessDocTooltip tooltipId={dataTooltipId} labelText={labelText} className={css || ''} />
 }
+
+export function escapeNewlines(input: string): string {
+  if (typeof input === 'string') {
+    return input.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
+  }
+  return input
+}

--- a/packages/uicore/src/components/FormikForm/utils.tsx
+++ b/packages/uicore/src/components/FormikForm/utils.tsx
@@ -55,7 +55,7 @@ export const getFormFieldLabel = (
   return <HarnessDocTooltip tooltipId={dataTooltipId} labelText={labelText} className={css || ''} />
 }
 
-export function escapeNewlines(input: string): string {
+export function escapeNewlines(input: string | number): string | number {
   if (typeof input === 'string') {
     return input.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
   }


### PR DESCRIPTION
- handled number cases for escape new line function

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
