### PR TITLE
feat: [CDS-74577]: Adding support for custom newItemRenderer label

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.149.0",
+  "version": "3.150.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -210,7 +210,7 @@ export function Select(props: SelectProps): React.ReactElement {
                 intent="primary"
                 minimal
                 text={props.newItemRenderer?.(query)}
-                icon="plus"
+                icon="chevron-right"
                 className={css.createNewItemButton}
                 onClick={handleClick as React.MouseEventHandler<Element>}
               />

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -54,7 +54,7 @@ export interface SelectProps
   size?: SelectSize
   items: Props['items'] | (() => Promise<Props['items']>)
   allowCreatingNewItems?: boolean
-  newItemRenderer?: (query: string) => React.ReactNode
+  newItemRenderer?: (query: string, clickHandler?: React.MouseEventHandler<Element>) => React.ReactNode
   name?: string
   whenPopoverClosed?: (node: HTMLElement) => void
   addClearBtn?: boolean
@@ -205,14 +205,7 @@ export function Select(props: SelectProps): React.ReactElement {
           ) : null}
           {props.allowCreatingNewItems && !isExactQueryElPresent ? (
             props.newItemRenderer ? (
-              <Button
-                intent="primary"
-                minimal
-                text={props.newItemRenderer?.(query)}
-                icon="chevron-right"
-                className={css.createNewItemButton}
-                onClick={handleClick as React.MouseEventHandler<Element>}
-              />
+              props.newItemRenderer?.(query, handleClick)
             ) : (
               <Button
                 intent="primary"

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -54,6 +54,7 @@ export interface SelectProps
   size?: SelectSize
   items: Props['items'] | (() => Promise<Props['items']>)
   allowCreatingNewItems?: boolean
+  newItemRenderer?: (query: string) => string
   name?: string
   whenPopoverClosed?: (node: HTMLElement) => void
   addClearBtn?: boolean
@@ -202,16 +203,27 @@ export function Select(props: SelectProps): React.ReactElement {
           {items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase())).length === 0 ? (
             <div className={css.noResultsFound}>No Match Found</div>
           ) : null}
-          {props.allowCreatingNewItems && !isExactQueryElPresent && (
-            <Button
-              intent="primary"
-              minimal
-              text={query}
-              icon="plus"
-              className={css.createNewItemButton}
-              onClick={handleClick as React.MouseEventHandler<Element>}
-            />
-          )}
+          {props.allowCreatingNewItems &&
+            !isExactQueryElPresent &&
+            (props.newItemRenderer ? (
+              <Button
+                intent="primary"
+                minimal
+                text={props.newItemRenderer?.(query)}
+                icon="plus"
+                className={css.createNewItemButton}
+                onClick={handleClick as React.MouseEventHandler<Element>}
+              />
+            ) : (
+              <Button
+                intent="primary"
+                minimal
+                text={query}
+                icon="plus"
+                className={css.createNewItemButton}
+                onClick={handleClick as React.MouseEventHandler<Element>}
+              />
+            ))}
         </React.Fragment>
       )
   }

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -54,7 +54,7 @@ export interface SelectProps
   size?: SelectSize
   items: Props['items'] | (() => Promise<Props['items']>)
   allowCreatingNewItems?: boolean
-  newItemRenderer?: (query: string) => string
+  newItemRenderer?: (query: string) => React.ReactNode
   name?: string
   whenPopoverClosed?: (node: HTMLElement) => void
   addClearBtn?: boolean

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -203,9 +203,8 @@ export function Select(props: SelectProps): React.ReactElement {
           {items.filter(item => item.label.toString().toLowerCase().includes(query.toLowerCase())).length === 0 ? (
             <div className={css.noResultsFound}>No Match Found</div>
           ) : null}
-          {props.allowCreatingNewItems &&
-            !isExactQueryElPresent &&
-            (props.newItemRenderer ? (
+          {props.allowCreatingNewItems && !isExactQueryElPresent ? (
+            props.newItemRenderer ? (
               <Button
                 intent="primary"
                 minimal
@@ -223,7 +222,8 @@ export function Select(props: SelectProps): React.ReactElement {
                 className={css.createNewItemButton}
                 onClick={handleClick as React.MouseEventHandler<Element>}
               />
-            ))}
+            )
+          ) : null}
         </React.Fragment>
       )
   }


### PR DESCRIPTION
Editing support for custom label for new item label in Select. 
Before label was fixed as : **+ query** , Now consumer can use any label, ex:  **> Select branch main-patch**
Changes were done after the feedback in earlier flow as discussed in [CDS-74577](https://harness.atlassian.net/browse/CDS-74577)
**Before fix**
<img width="783" alt="Screenshot 2023-08-28 at 10 03 45 AM" src="https://github.com/harness/uicore/assets/63278928/67ed0087-33b1-47d8-bdbb-3ece8667a305">



**After fix :** 
Renderer used to test in NGUI :

```
  const renderCustomSelectBranch = (
    query: string,
    clickHandler?: React.MouseEventHandler<Element>
  ): React.ReactElement => (
    <Button
      intent="primary"
      minimal
      text={`Select branch ${query}`}
      icon="chevron-right"
      className={css.createNewItemButton}
      onClick={clickHandler}
    />
  )
```

<img width="791" alt="Screenshot 2023-08-28 at 10 01 16 AM" src="https://github.com/harness/uicore/assets/63278928/5087f602-3c30-45df-9689-6b9dd107d80d">



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`


[CDS-74577]: https://harness.atlassian.net/browse/CDS-74577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ