### PR TITLE
fix: [CDS-77988]: For multiselecttypeinput set defaultValueToReset as []

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.150.0",
+  "version": "3.151.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -427,6 +427,7 @@ export const MultiSelectTypeInput: React.FC<MultiSelectTypeInputProps> = ({ mult
       {...rest}
       fixedTypeComponentProps={multiSelectProps}
       fixedTypeComponent={MultiSelectTypeInputTypeComponent}
+      defaultValueToReset={[]}
     />
   )
 }


### PR DESCRIPTION
**Issue:** On changing multiselecttypeinput from expression or runtime to fixed, page crashed
**Fix:** This issue was because defaultvalue was getting reset to empty string. So updated it to empty array which is expected default value.

Before fix:

https://github.com/harness/uicore/assets/98508399/2a36d95f-4ca9-4653-bbe1-3bc1349703bc

After fix:

https://github.com/harness/uicore/assets/98508399/89d2fd9a-983c-4343-8615-3baa8b258f6c

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
