### PR TITLE
fix: [CDS-78728]: FormInput.MultiSelect showing different placeholders on select and empty state

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.151.0",
+  "version": "3.151.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -8,6 +8,7 @@
 import React, { ReactElement } from 'react'
 import cx from 'classnames'
 import { Position } from '@blueprintjs/core'
+import { defaultTo } from 'lodash-es'
 import { MultiSelect as BPMultiSelect, IMultiSelectProps, IItemRendererProps } from '@blueprintjs/select'
 
 import css from './MultiSelect.css'
@@ -15,7 +16,6 @@ import { Button } from '../../components/Button/Button'
 import { Text } from '../../components/Text/Text'
 import { Icon } from '@harness/icons'
 import { Utils } from '../../core/Utils'
-import { defaultTo } from 'lodash-es'
 
 export interface MultiSelectOption {
   label: string

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -15,6 +15,7 @@ import { Button } from '../../components/Button/Button'
 import { Text } from '../../components/Text/Text'
 import { Icon } from '@harness/icons'
 import { Utils } from '../../core/Utils'
+import { defaultTo } from 'lodash-es'
 
 export interface MultiSelectOption {
   label: string
@@ -216,7 +217,9 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
       {...rest}
       tagInputProps={{
         disabled,
-        placeholder: Utils.getSelectComponentPlaceholder(rest?.placeholder),
+        placeholder: Utils.getSelectComponentPlaceholder(
+          defaultTo(rest?.placeholder, rest?.tagInputProps?.inputProps?.placeholder)
+        ),
         tagProps: value => {
           return {
             className: cx(css.tag, {


### PR DESCRIPTION

Summary:- 

- The placeholder was being passed as `inputProps` under `tagInputProps` , but the component only considered the placeholder being passed at root level.


https://github.com/harness/uicore/assets/106532291/2bf73383-3865-48ee-bbf8-7acde7442453




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
