### PR TITLE
feat: [SSCA-642] ssca nav icons increment version

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/icons",
-  "version": "1.185.0",
+  "version": "1.186.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/icons.umd.js",


### PR DESCRIPTION
Increased version in prev PR but a parallel PR merged in between with same version, so the new icons are not available in that

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
