### PR TITLE
fix: breadcrumbs snapshot changes revert

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.152.0",
+  "version": "3.152.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Breadcrumbs/Breadcrumbs.css
+++ b/packages/uicore/src/components/Breadcrumbs/Breadcrumbs.css
@@ -7,4 +7,9 @@
 
 .breadcrumbs {
   line-height: 18px;
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
 }

--- a/packages/uicore/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/uicore/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -26,12 +26,15 @@ export interface BreadcrumbsProps {
 
 export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ links = [], className = '' }) => {
   return (
-    <Layout.Horizontal className={cx(css.breadcrumbs, className)}>
+    <Layout.Horizontal
+      flex={{ align: 'center-center', justifyContent: 'flex-start' }}
+      className={cx(css.breadcrumbs, className)}>
       {links.map((link: Breadcrumb) => {
         return (
           <Layout.Horizontal flex={{ align: 'center-center', justifyContent: 'flex-start' }} key={link.label}>
             <Link
               to={link.url}
+              className={css.breadcrumb}
               onClick={event => {
                 if (link.onClick) {
                   event.preventDefault()

--- a/packages/uicore/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/packages/uicore/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -3,12 +3,13 @@
 exports[`Render basic component should check snapshot with name 1`] = `
 <div>
   <div
-    class="horizontal layout-spacing-undefined StyledProps--main breadcrumbs"
+    class="horizontal layout-spacing-undefined StyledProps--main breadcrumbs StyledProps--flex StyledProps--flex-align-center-center StyledProps--flex-justifyContent-flex-start"
   >
     <div
       class="horizontal layout-spacing-undefined StyledProps--main StyledProps--flex StyledProps--flex-align-center-center StyledProps--flex-justifyContent-flex-start"
     >
       <a
+        class="breadcrumb"
         href="/"
       >
         <span
@@ -57,6 +58,7 @@ exports[`Render basic component should check snapshot with name 1`] = `
       class="horizontal layout-spacing-undefined StyledProps--main StyledProps--flex StyledProps--flex-align-center-center StyledProps--flex-justifyContent-flex-start"
     >
       <a
+        class="breadcrumb"
         href="/"
       >
         <span
@@ -103,6 +105,7 @@ exports[`Render basic component should check snapshot with name 1`] = `
       class="horizontal layout-spacing-undefined StyledProps--main StyledProps--flex StyledProps--flex-align-center-center StyledProps--flex-justifyContent-flex-start"
     >
       <a
+        class="breadcrumb"
         href="/"
       >
         <p


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
