### PR TITLE
fix: [CDS-79162]: edit expressions in firefox

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.152.1",
+  "version": "3.152.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.css
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.css
@@ -17,4 +17,5 @@
   padding-right: 35px;
   border-radius: var(--spacing-2);
   word-break: break-all;
+  white-space: pre;
 }

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -169,7 +169,7 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
         {...rest}
         className={cx(css.editable, textAreaClassName)}
         ref={inputRef}
-        contentEditable={'plaintext-only' as any}
+        contentEditable={true}
         onKeyDown={this.handleKeyDown.bind(this)}
         dangerouslySetInnerHTML={{ __html: highlight(deserialize(value + ' ')) }}
       />

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -169,6 +169,10 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
         {...rest}
         className={cx(css.editable, textAreaClassName)}
         ref={inputRef}
+        /**
+         * https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
+         * plaintext-only is not supported in firefox
+         */
         contentEditable={true}
         onKeyDown={this.handleKeyDown.bind(this)}
         dangerouslySetInnerHTML={{ __html: highlight(deserialize(value + ' ')) }}


### PR DESCRIPTION

- `plaintext-only` is not supported for `firefox` .
-  MDN-Docs :-  https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
- https://bugzilla.mozilla.org/show_bug.cgi?id=1291467 feature request to add support for `plaintext-only` in firefox


https://github.com/harness/uicore/assets/106532291/ab84256b-3f5f-4c11-93b3-d7e28a95a0ef



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
