### PR TITLE
fix: [CDS-80395]: fix failing TCs

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.152.5",
+  "version": "3.152.6",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/GridListToggle/GridListToggle.css
+++ b/packages/uicore/src/components/GridListToggle/GridListToggle.css
@@ -19,10 +19,22 @@
   }
 }
 
+.splitUnselected {
+  box-shadow: none !important;
+  &:hover {
+    color: var(--primary-6) !important;
+  }
+}
+
 .gridButton,
-.splitButton,
 .listButton {
   padding-left: 0px !important;
+  padding-right: 0px !important;
+  min-width: 24px;
+}
+
+.splitButton {
+  padding-left: var(--spacing-small) !important;
   padding-right: 0px !important;
   min-width: 24px;
 }

--- a/packages/uicore/src/components/GridListToggle/GridListToggle.tsx
+++ b/packages/uicore/src/components/GridListToggle/GridListToggle.tsx
@@ -41,7 +41,7 @@ export function GridListToggle(props: GridListToggleProps): JSX.Element {
       <Button
         className={cx(
           {
-            [css.gridUnselected]: selectedView === Views.LIST
+            [css.gridUnselected]: selectedView !== Views.GRID
           },
           css.gridButton
         )}
@@ -58,10 +58,9 @@ export function GridListToggle(props: GridListToggleProps): JSX.Element {
       <Button
         className={cx(
           {
-            [css.listUnselected]: selectedView === Views.GRID
+            [css.listUnselected]: selectedView !== Views.LIST
           },
-          css.listButton,
-          css.gridButton
+          css.listButton
         )}
         minimal
         icon={icons?.right ?? 'list'}
@@ -77,7 +76,7 @@ export function GridListToggle(props: GridListToggleProps): JSX.Element {
         <Button
           className={cx(
             {
-              [css.listUnselected]: selectedView === Views.SPLIT_VIEW
+              [css.splitUnselected]: selectedView !== Views.SPLIT_VIEW
             },
             css.splitButton
           )}

--- a/packages/uicore/src/components/GridListToggle/__snapshots__/GridListToggle.test.tsx.snap
+++ b/packages/uicore/src/components/GridListToggle/__snapshots__/GridListToggle.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`GridListToggle test When no props are passed By default Grid view shoul
       </span>
     </button>
     <button
-      class="bp3-button bp3-minimal button StyledProps--font StyledProps--main listUnselected listButton gridButton with-current-color iconOnly without-shadow withLeftIcon"
+      class="bp3-button bp3-minimal button StyledProps--font StyledProps--main listUnselected listButton with-current-color iconOnly without-shadow withLeftIcon"
       data-testid="list-view"
       data-tooltip-id="list-view"
       type="button"
@@ -93,7 +93,7 @@ exports[`GridListToggle test When props are passed - initialSelectedView: GRID B
       </span>
     </button>
     <button
-      class="bp3-button bp3-minimal button StyledProps--font StyledProps--main listUnselected listButton gridButton with-current-color iconOnly without-shadow withLeftIcon"
+      class="bp3-button bp3-minimal button StyledProps--font StyledProps--main listUnselected listButton with-current-color iconOnly without-shadow withLeftIcon"
       data-testid="list-view"
       data-tooltip-id="list-view"
       type="button"
@@ -154,7 +154,7 @@ exports[`GridListToggle test When props are passed - initialSelectedView: LIST B
       </span>
     </button>
     <button
-      class="bp3-button bp3-minimal button StyledProps--font StyledProps--main listButton gridButton StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
+      class="bp3-button bp3-minimal button StyledProps--font StyledProps--main listButton StyledProps--intent-primary with-current-color without-shadow withLeftIcon"
       data-testid="list-view"
       data-tooltip-id="list-view"
       type="button"


### PR DESCRIPTION
This fixes failing snapshot tests in ng-ui by removing `gridButton` class which was added in https://github.com/harness/uicore/pull/1171 to the `LIST` view button component

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
