### PR TITLE
fix: [CDS-78994]: Make TagInput usable for any item type

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.152.6",
+  "version": "3.152.7",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TagInput/TagInput.tsx
+++ b/packages/uicore/src/components/TagInput/TagInput.tsx
@@ -98,15 +98,6 @@ function FailToFetch({ error, retry }: { error: string; retry: () => void }) {
   )
 }
 
-const getId = (item: string | { value: string } | any) => (typeof item === 'object' ? item.value : item)
-
-const getLabelFromItems = (
-  item: string | { value: string; label: string } | any,
-  items: string[] | Array<{ value: string; label: string }> | any[] = []
-) => items.find(i => (typeof i === 'object' ? i?.value === item : i === item))?.label || item
-
-const getLabel = (item: string | { label: string } | any) => (typeof item === 'object' ? item.label : item)
-
 export function TagInput<T>(props: TagInputProps<T>) {
   const {
     selectedItems: _selectedItems,
@@ -151,7 +142,6 @@ export function TagInput<T>(props: TagInputProps<T>) {
   const onItemSelect = useCallback(
     (item: T) => {
       const index = selectedItems.findIndex(_item => keyOf(_item) === keyOf(item))
-      item = getId(item)
       const isSelectedItemAlreadyCreated = createdItems.find((_item: T) => keyOf(_item) === keyOf(item))
       if (index >= 0 && !isSelectedItemAlreadyCreated) {
         // item was already selected before
@@ -274,7 +264,7 @@ export function TagInput<T>(props: TagInputProps<T>) {
         return (
           <MenuItem
             key={keyOf(item)}
-            text={labelFor(getLabel(item))}
+            text={labelFor(item)}
             icon={isItemSelected(item) ? 'tick' : 'blank'}
             onClick={itemProps.handleClick}
             active={itemProps.modifiers.active}
@@ -284,7 +274,7 @@ export function TagInput<T>(props: TagInputProps<T>) {
       createNewItemFromQuery={(allowNewTag && itemFromNewTag) || undefined}
       createNewItemRenderer={renderCreateNewTag}
       onItemSelect={onItemSelect}
-      tagRenderer={(item: T) => labelFor(getLabelFromItems(item, items))}
+      tagRenderer={labelFor}
       tagInputProps={{
         disabled: readonly,
         onRemove: (_value: string, index: number) => {


### PR DESCRIPTION
TagInput component uses a generic type for items, but a few functions inside it expect items to have certain keys (like value, label, etc.) if they are objects, making it impossible to use this for any item type. This PR removes these functions.

Verified that removing these functions doesn't break anything.


