### PR TITLE
fix: [CDS-81644]: variable not respecting the width in variables window

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.152.7",
+  "version": "3.152.8",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.css
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.css
@@ -17,5 +17,5 @@
   padding-right: 35px;
   border-radius: var(--spacing-2);
   word-break: break-all;
-  white-space: pre;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
- fix variable not respecting the width in variables window as the `whitespace:pre` doesn't wrap the text where as `pre-wrap` solves our use case

Tested Scenarios :- 

- Edit expressions in `chrome` with long expressions
- Edit expressions in `firefox` with long expressions
- Edit long expressions in `harness-core-ui`


https://github.com/harness/uicore/assets/106532291/8347df09-1ebd-4dc3-8c8c-f66ad107daa2




<img width="613" alt="Screenshot 2023-10-17 at 12 03 08 PM" src="https://github.com/harness/uicore/assets/106532291/79fe0221-3205-4210-bb69-1f077d0c7ddb">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
