### PR TITLE
fix: [FFM-9721]: Ensure value defaults to empty array

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.153.0",
+  "version": "3.153.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -32,7 +32,7 @@ import {
   FileInput as BpFileInput,
   HTMLInputProps
 } from '@blueprintjs/core'
-import { compact, defaultTo, get, isNil, omit, uniq } from 'lodash-es'
+import { defaultTo, get, isNil, omit, uniq } from 'lodash-es'
 import cx from 'classnames'
 import css from './FormikForm.css'
 import i18n from './FormikForm.i18n'
@@ -1226,14 +1226,12 @@ const FormMultiSelectTypeInput = (props: FormMultiSelectTypeInputProps & FormikC
     ...rest
   } = restProps
   const autoComplete = props.autoComplete || getDefaultAutoCompleteValue()
+
   let value = get(formik?.values, name)
   if (useValue && getMultiTypeFromValue(value) === MultiTypeInputType.FIXED) {
-    value = compact(
-      value.map((val: string) => {
-        return selectItems.filter(item => item.value === val)
-      })
-    )
+    value = Array.isArray(value) ? selectItems.filter(item => value.includes(item.value)) : []
   }
+
   return (
     <FormGroup
       label={getFormFieldLabel(label, name, props)}


### PR DESCRIPTION
This PR fixes an issue whereby using the `useValue` prop with no initial value set on the `FormMultiSelectTypeInput` would result in an error being thrown.