### PR TITLE
fix: [CDS-80690]: Use empty string if value is nil for controlled inputs

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.154.0",
+  "version": "3.154.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -901,7 +901,7 @@ const TextArea = (props: TextAreaProps & FormikContextProps<any>) => {
         disabled={disabled}
         placeholder={placeholder}
         onBlur={() => formik?.setFieldTouched(name, true, false)}
-        value={get(formik?.values, name)}
+        value={get(formik?.values, name) ?? ''}
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
           formik?.setFieldValue(name, e.currentTarget.value)
           onChange?.(e)

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -371,7 +371,7 @@ function MultiTextInputFixedTypeComponent(props: FixedTypeComponentProps & Multi
     <InputGroup
       className={css.input}
       {...rest}
-      value={value as string}
+      value={(value as string) ?? ''}
       disabled={disabled}
       onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
         onChange?.(event.target.value, MultiTypeInputValue.STRING, MultiTypeInputType.FIXED)


### PR DESCRIPTION
Update `FormInput.TextArea` and `FormInput.MultiTextInput` to pass an empty string to the underlying input element if `value` is null/undefined to fix React warnings related to controlled components.

Example warning:

<img width="1120" alt="image" src="https://github.com/harness/uicore/assets/52284933/a3a6c4ca-e031-4671-8138-7f83baf745bc">



