### PR TITLE
feat: [SRM-16021]: Added Stepper component

### DIFF
--- a/packages/uicore/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/uicore/src/components/Stepper/Stepper.stories.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import type { Meta, Story } from '@storybook/react'
+import { Title, Subtitle, ArgsTable, Stories, PRIMARY_STORY, Primary } from '@storybook/addon-docs/blocks'
+import { Stepper } from './Stepper'
+import { StepperProps } from './Stepper.types'
+import { StepList } from './__tests__/Stepper.mock'
+import { omit } from 'lodash-es'
+
+export default {
+  title: 'Components / Stepper',
+
+  component: Stepper,
+  parameters: {
+    docs: {
+      source: {
+        type: 'code'
+      },
+
+      page: function PageDescription() {
+        return (
+          <>
+            <Title>StepsProgress</Title>
+            <Subtitle>
+              <pre>
+                <code>{`import {Stepper} from '@harness/uicore'`}</code>
+              </pre>
+            </Subtitle>
+
+            <Primary />
+            <ArgsTable story={PRIMARY_STORY} />
+
+            <Stories />
+          </>
+        )
+      }
+    }
+  },
+  decorators: [Story => <Story />]
+} as Meta
+export const Basic: Story<StepperProps> = args => {
+  const { id = 'createSLOTabs', isStepValid = () => true, runValidationOnMount = false, stepList = StepList } = args
+  const argsCopy = omit(args, ['steps', 'intent', 'current', 'currentStatus'])
+  return (
+    <Stepper
+      id={id}
+      isStepValid={isStepValid}
+      runValidationOnMount={runValidationOnMount}
+      stepList={stepList}
+      {...argsCopy}
+    />
+  )
+}
+export const StepperWithAllValidSteps: Story<StepperProps> = args => {
+  const { id = 'createSLOTabs', isStepValid = () => true, runValidationOnMount = false, stepList = StepList } = args
+  const argsCopy = omit(args, ['id', 'isStepValid', 'runValidationOnMount', 'stepList'])
+  return (
+    <Stepper
+      id={id}
+      isStepValid={isStepValid}
+      runValidationOnMount={runValidationOnMount}
+      stepList={stepList}
+      {...argsCopy}
+    />
+  )
+}
+
+export const ValidateStepOnNext: Story<StepperProps> = args => {
+  const { id = 'createSLOTabs', isStepValid = () => false, runValidationOnMount = false, stepList = StepList } = args
+  const argsCopy = omit(args, ['id', 'isStepValid', 'runValidationOnMount', 'stepList'])
+  return (
+    <Stepper
+      id={id}
+      isStepValid={isStepValid}
+      runValidationOnMount={runValidationOnMount}
+      stepList={stepList}
+      {...argsCopy}
+    />
+  )
+}
+
+export const ValidateAllStepsOnMount: Story<StepperProps> = args => {
+  const { id = 'createSLOTabs', isStepValid = () => false, runValidationOnMount = true, stepList = StepList } = args
+  const argsCopy = omit(args, ['id', 'isStepValid', 'runValidationOnMount', 'stepList'])
+  return (
+    <Stepper
+      id={id}
+      isStepValid={isStepValid}
+      runValidationOnMount={runValidationOnMount}
+      stepList={stepList}
+      {...argsCopy}
+    />
+  )
+}

--- a/packages/uicore/src/components/Stepper/Stepper.tsx
+++ b/packages/uicore/src/components/Stepper/Stepper.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { useState } from 'react'
+import type { StepperProps } from './Stepper.types'
+import Step from './components/Step/Step'
+import { Layout } from '../..'
+
+export const StepperContext = React.createContext<StepperProps>({ id: '', stepList: [] })
+
+export const Stepper = (props: React.PropsWithChildren<StepperProps>): React.ReactElement => {
+  const { stepList, isStepValid, onStepChange, runValidationOnMount, hideTitleWhenActive, activeStepId } = props
+  const [selectedStepId, setSelectedStepId] = useState(() => activeStepId || stepList[0]?.id)
+  return (
+    <StepperContext.Provider value={{ ...props }}>
+      <Layout.Vertical margin="xlarge" data-testid="Stepper_main">
+        {stepList?.map((step, index) => {
+          return (
+            <Step
+              key={step.id}
+              step={step}
+              index={index}
+              stepList={stepList}
+              selectedStepId={selectedStepId}
+              isStepValid={isStepValid}
+              setSelectedStepId={setSelectedStepId}
+              onStepChange={onStepChange}
+              runValidationOnMount={runValidationOnMount}
+              isOptional={step.isOptional}
+              hideTitleWhenActive={hideTitleWhenActive}
+            />
+          )
+        })}
+      </Layout.Vertical>
+    </StepperContext.Provider>
+  )
+}

--- a/packages/uicore/src/components/Stepper/Stepper.types.ts
+++ b/packages/uicore/src/components/Stepper/Stepper.types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+export interface StepDetailsInterface {
+  id: string
+  title: string
+  subTitle?: string
+  panel: React.ReactElement
+  preview?: React.ReactElement
+  isOptional?: boolean
+  helpPanelReferenceId?: string
+  errorMessage?: string[]
+  nextButtonTitle?: string
+  disableNext?: () => boolean
+}
+
+export interface StepperProps {
+  id: string
+  stepList: StepDetailsInterface[]
+  onStepChange?: (id: string) => void
+  isStepValid?: (selectedTabId: string) => boolean
+  runValidationOnMount?: boolean
+  hideTitleWhenActive?: boolean
+  activeStepId?: string
+}

--- a/packages/uicore/src/components/Stepper/__tests__/Stepper.mock.tsx
+++ b/packages/uicore/src/components/Stepper/__tests__/Stepper.mock.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { Text } from '../../..'
+
+export const StepList = [
+  {
+    id: 'Step1',
+    title: 'This is Step 1',
+    panel: <Text>Panel Step 1</Text>,
+    preview: <Text>Preview Panel Step 1</Text>
+  },
+  {
+    id: 'Step2',
+    title: 'This is Step 2',
+    panel: <Text>Panel Step 2</Text>,
+    preview: <Text>Preview Panel Step 2</Text>
+  },
+  {
+    id: 'Step3',
+    title: 'This is Step 3',
+    panel: <Text>Panel Step 3</Text>,
+    preview: <Text>Preview Panel Step 3</Text>
+  }
+]

--- a/packages/uicore/src/components/Stepper/__tests__/Stepper.test.tsx
+++ b/packages/uicore/src/components/Stepper/__tests__/Stepper.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Stepper } from '../Stepper'
+import { StepList } from './Stepper.mock'
+import { Button } from '../../..'
+
+const Wrapped = ({
+  isStepValid,
+  runValidationOnMount
+}: {
+  isStepValid: (stepId: string) => boolean
+  runValidationOnMount?: boolean
+}): React.ReactElement => {
+  const [validateAll, setValidateAll] = useState(runValidationOnMount)
+  return (
+    <>
+      <Stepper id="createSLOTabs" isStepValid={isStepValid} runValidationOnMount={validateAll} stepList={StepList} />
+      <Button text="save" onClick={() => setValidateAll(true)} />
+    </>
+  )
+}
+
+describe('Validate Stepper', () => {
+  test('render in create mode', async () => {
+    const isStepValid = jest.fn().mockReturnValue(true)
+    const { container, getByText } = render(<Wrapped isStepValid={isStepValid} />)
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [data-icon="Edit"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="ring"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="ring"]')).toBeInTheDocument()
+    expect(screen.getByText('Next')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="backButton"]')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByText('Next'))
+    expect(getByText('Preview Panel Step 1')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [data-icon="Edit"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="ring"]')).toBeInTheDocument()
+    expect(screen.getByText('Back')).toBeInTheDocument()
+    expect(screen.getByText('Next')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Next'))
+    expect(getByText('Preview Panel Step 2')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [data-icon="Edit"]')).toBeInTheDocument()
+    expect(screen.getByText('Back')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="nextButton"]')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByText('save'))
+
+    // goto step 1 ( edit icon not visible on selected one as status is available )
+    await userEvent.click(container.querySelector('[data-testid="steptitle_Step1"]')!)
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="tick-circle"]')).toBeInTheDocument()
+    await userEvent.click(container.querySelector('[data-testid="steptitle_Step2"]')!)
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="tick-circle"]')).toBeInTheDocument()
+    await userEvent.click(container.querySelector('[data-testid="steptitle_Step3"]')!)
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+
+    // Back button works as expected
+    await userEvent.click(screen.getByText('Back'))
+    expect(getByText('Panel Step 2')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Back'))
+    expect(getByText('Panel Step 1')).toBeInTheDocument()
+  })
+
+  test('On clicking save in create mode all steps status is updated ', async () => {
+    const isStepValid = jest.fn().mockReturnValue(true)
+    const { container } = render(<Wrapped isStepValid={isStepValid} />)
+    await userEvent.click(screen.getByText('save'))
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+  })
+
+  test('render in edit mode', async () => {
+    const isStepValid = (stepId: string): boolean => {
+      if (stepId === 'Step3') {
+        return false
+      } else {
+        return true
+      }
+    }
+    const { container, getByText } = render(<Wrapped isStepValid={isStepValid} runValidationOnMount={true} />)
+
+    // load with status with status
+    expect(container.querySelector('[data-testid="steptitle_Step1"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step2"] [icon="tick-circle"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="steptitle_Step3"] [icon="warning-sign"]')).toBeInTheDocument()
+
+    // directly jump to step 3 in error state
+    await userEvent.click(container.querySelector('[data-testid="steptitle_Step3"]')!)
+    expect(getByText('Panel Step 3')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Back'))
+    expect(getByText('Panel Step 2')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Back'))
+    expect(getByText('Panel Step 1')).toBeInTheDocument()
+  })
+
+  test('Render with empty step list', () => {
+    const { container } = render(
+      <Stepper id="createSLOTabs" isStepValid={jest.fn()} runValidationOnMount={false} stepList={[]} />
+    )
+    expect(container.querySelector('[data-testid="Stepper_main"]')).toBeInTheDocument()
+  })
+})

--- a/packages/uicore/src/components/Stepper/components/Step/Step.constants.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/Step.constants.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+export enum StepStatus {
+  ERROR = 'ERROR',
+  SUCCESS = 'SUCCESS',
+  INCONCLUSIVE = 'INCONCLUSIVE'
+}

--- a/packages/uicore/src/components/Stepper/components/Step/Step.module.css
+++ b/packages/uicore/src/components/Stepper/components/Step/Step.module.css
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.stepContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.borderLeft {
+  border-left: 1px solid var(--grey-200);
+}
+
+.alignContainerRight {
+  padding: var(--spacing-small) !important;
+  margin: 0 !important;
+  margin-left: 18px !important;
+}
+
+.card {
+  min-width: 100%;
+}
+
+.bottomMargin {
+  margin-bottom: var(--spacing-huge) !important;
+}
+
+.stepMargin {
+  padding: var(--spacing-small) var(--spacing-xlarge) var(--spacing-xlarge) var(--spacing-large) !important;
+}
+
+.stepSubtitle {
+  padding: 0 calc(var(--spacing-medium) + var(--spacing-tiny)) !important;
+}

--- a/packages/uicore/src/components/Stepper/components/Step/Step.module.scss.d.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/Step.module.scss.d.ts
@@ -1,0 +1,18 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly alignContainerRight: string
+  readonly borderLeft: string
+  readonly bottomMargin: string
+  readonly card: string
+  readonly stepContainer: string
+  readonly stepMargin: string
+  readonly stepSubtitle: string
+}
+export default styles

--- a/packages/uicore/src/components/Stepper/components/Step/Step.tsx
+++ b/packages/uicore/src/components/Stepper/components/Step/Step.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React, { useState, useCallback, useMemo } from 'react'
+import cx from 'classnames'
+import { FontVariation } from '@harness/design-system'
+import { HelpPanel, HelpPanelType } from '@harness/help-panel'
+import type { StepPropsInterface, StepStatusType } from './Step.types'
+import { StepTitle } from './components/StepTitle/StepTitle'
+import { StepNavButtons } from './components/StepNavButtons/StepNavButtons'
+import { StepStatus } from './Step.constants'
+import { getStepStatus, getTitleStatus } from './Step.utils'
+import { Container, Card, Text } from '../../../../'
+import css from './Step.module.css'
+
+const Step = ({
+  stepList,
+  selectedStepId,
+  isStepValid,
+  step,
+  index,
+  onStepChange,
+  setSelectedStepId,
+  runValidationOnMount,
+  isOptional,
+  hideTitleWhenActive
+}: StepPropsInterface): JSX.Element => {
+  const selectedStepIndex = stepList.map(item => item.id).indexOf(selectedStepId || '')
+  const [stepStatus, setStepStatus] = useState<StepStatusType>(StepStatus.INCONCLUSIVE)
+  const isLastStep = selectedStepIndex === stepList.length - 1
+  const isCurrentStep = selectedStepIndex === index
+  const { id, panel, preview, helpPanelReferenceId } = step
+
+  const onTitleClick = useCallback(
+    (titleIndex: number): void => {
+      setSelectedStepId(stepList[titleIndex].id)
+      onStepChange?.(stepList[titleIndex].id)
+    },
+    [onStepChange, setSelectedStepId, stepList]
+  )
+
+  const onContinue = useCallback(
+    (selectedIndex: number, skipValidation = false): void => {
+      const validStatus = !!isStepValid?.(step.id)
+      if (validStatus || skipValidation) {
+        setSelectedStepId(stepList[selectedIndex].id)
+        onStepChange?.(stepList[selectedIndex].id)
+      }
+      setStepStatus(getStepStatus(validStatus))
+    },
+    [isStepValid, onStepChange, setSelectedStepId, step.id, stepList]
+  )
+
+  const stepTitleStatus = useMemo(
+    () =>
+      getTitleStatus({
+        stepId: step.id,
+        currentStepStatus: stepStatus,
+        runValidationOnMount: Boolean(runValidationOnMount),
+        isCurrentStep,
+        isStepValid
+      }),
+    [isStepValid, isCurrentStep, runValidationOnMount, step.id, stepStatus]
+  )
+
+  const isErrorMessageVisible = stepTitleStatus === StepStatus.ERROR
+  const isPreviewVisible = useMemo(() => selectedStepIndex > index && step.preview && !isErrorMessageVisible, [
+    index,
+    selectedStepIndex,
+    step.preview,
+    isErrorMessageVisible
+  ])
+
+  return (
+    <Container className={cx(css.stepContainer, index === stepList.length - 1 && css.bottomMargin)}>
+      <StepTitle
+        step={step}
+        index={index}
+        isCurrent={isCurrentStep}
+        stepStatus={stepTitleStatus}
+        onClick={onTitleClick}
+        isOptional={isOptional}
+        hideTitle={isCurrentStep ? hideTitleWhenActive : false}
+      />
+
+      {step.subTitle && (
+        <Container className={cx(css.alignContainerRight, css.borderLeft, css.stepSubtitle)}>
+          <Text font={{ variation: FontVariation.FORM_LABEL }}>{step.subTitle}</Text>
+        </Container>
+      )}
+      <Container
+        data-testid={`step_container_${id}`}
+        className={cx(css.alignContainerRight, {
+          [css.borderLeft]: index !== stepList.length - 1 || isLastStep,
+          [css.stepMargin]: isCurrentStep || isErrorMessageVisible || isPreviewVisible
+        })}>
+        {isPreviewVisible && (
+          <Container data-testid={`preview_${id}`} width={500}>
+            <>{preview}</>
+          </Container>
+        )}
+        {(isCurrentStep || isErrorMessageVisible) && (
+          <Container>
+            {isErrorMessageVisible && (
+              <>
+                {!step.errorMessage?.length ? (
+                  <Text margin={{ bottom: isCurrentStep ? 'large' : '' }} intent="danger">
+                    Required fields are missing or have incorrect data
+                  </Text>
+                ) : (
+                  step.errorMessage?.map((error, errorIndex) => {
+                    return (
+                      <Text key={errorIndex} margin={{ bottom: isCurrentStep ? 'large' : 'small' }} intent="danger">
+                        {error}
+                      </Text>
+                    )
+                  })
+                )}
+              </>
+            )}
+            {isCurrentStep && (
+              <>
+                <Card data-testid={`panel_${id}`} className={css.card}>
+                  {panel}
+                </Card>
+                <StepNavButtons
+                  index={index}
+                  onContinue={onContinue}
+                  isLastStep={isLastStep}
+                  nextButtonTitle={step.nextButtonTitle}
+                  disableNext={step?.disableNext}
+                />
+              </>
+            )}
+          </Container>
+        )}
+      </Container>
+      {isCurrentStep && helpPanelReferenceId && (
+        <HelpPanel referenceId={helpPanelReferenceId} type={HelpPanelType.FLOATING_CONTAINER} />
+      )}
+    </Container>
+  )
+}
+
+export default Step

--- a/packages/uicore/src/components/Stepper/components/Step/Step.types.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/Step.types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import type { StepDetailsInterface } from '../../Stepper.types'
+import type { StepStatus } from './Step.constants'
+
+export interface StepPropsInterface {
+  stepList: StepDetailsInterface[]
+  selectedStepId?: string
+  step: StepDetailsInterface
+  index: number
+  onStepChange?: (id: string) => void
+  isStepValid?: (selectedTabId: string) => boolean
+  runValidationOnMount?: boolean
+  isOptional?: boolean
+  setSelectedStepId: (id: string) => void
+  hideTitleWhenActive?: boolean
+}
+export type StepStatusType = keyof typeof StepStatus
+
+export interface GetTitleStatusProps {
+  stepId: string
+  runValidationOnMount: boolean
+  isCurrentStep: boolean
+  currentStepStatus: StepStatusType
+  isStepValid?: (selectedTabId: string) => boolean
+}

--- a/packages/uicore/src/components/Stepper/components/Step/Step.utils.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/Step.utils.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { StepStatus } from './Step.constants'
+import type { GetTitleStatusProps, StepStatusType } from './Step.types'
+
+export const getStepStatus = (value: boolean): StepStatusType => (value ? StepStatus.SUCCESS : StepStatus.ERROR)
+
+export const getTitleStatus = ({
+  runValidationOnMount,
+  stepId,
+  isCurrentStep,
+  isStepValid,
+  currentStepStatus
+}: GetTitleStatusProps): StepStatusType =>
+  runValidationOnMount
+    ? getStepStatus(!!isStepValid?.(stepId))
+    : isCurrentStep && currentStepStatus !== StepStatus.INCONCLUSIVE
+    ? getStepStatus(!!isStepValid?.(stepId))
+    : currentStepStatus

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepNavButtons/StepNavButtons.tsx
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepNavButtons/StepNavButtons.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import type { StepNavButtonsInterface } from './StepNavButtons.types'
+import { Button, Layout, ButtonVariation } from '../../../../../../'
+
+export const StepNavButtons = ({
+  index,
+  isLastStep,
+  onContinue,
+  nextButtonTitle,
+  disableNext
+}: StepNavButtonsInterface): JSX.Element => {
+  return (
+    <Layout.Horizontal spacing="small" padding={{ top: 'xlarge' }}>
+      {index > 0 && (
+        <Button
+          data-testid="backButton"
+          variation={ButtonVariation.SECONDARY}
+          onClick={() => onContinue(index - 1, true)}
+          icon={'chevron-left'}>
+          Back
+        </Button>
+      )}
+      {!isLastStep && (
+        <Button
+          data-testid="nextButton"
+          variation={ButtonVariation.PRIMARY}
+          text={nextButtonTitle ? nextButtonTitle : 'Next'}
+          onClick={() => onContinue(index + 1)}
+          rightIcon={'chevron-right'}
+          disabled={disableNext?.()}
+        />
+      )}
+    </Layout.Horizontal>
+  )
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepNavButtons/StepNavButtons.types.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepNavButtons/StepNavButtons.types.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+export interface StepNavButtonsInterface {
+  index: number
+  isLastStep: boolean
+  onContinue: (index: number, skipValidation?: boolean) => void
+  nextButtonTitle?: string
+  disableNext?: () => boolean
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.constants.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.constants.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { IconName } from '@harness/icons'
+import { Color } from '@harness/design-system'
+
+export const SuccessState = {
+  icon: 'tick-circle',
+  cursor: 'pointer',
+  iconColor: 'primary7',
+  labelColor: Color.PRIMARY_7
+}
+
+export const ErrorState = {
+  icon: 'warning-sign',
+  cursor: 'not-allowed',
+  iconColor: 'error',
+  labelColor: Color.PRIMARY_10
+}
+
+export const DefaultState = {
+  cursor: 'not-allowed',
+  icon: 'ring' as IconName,
+  iconColor: 'primary9',
+  labelColor: Color.PRIMARY_10
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.module.css
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.module.css
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.editIcon {
+  background: var(--primary) !important;
+  color: var(--white) !important;
+  padding: var(--spacing-1) !important;
+  border-radius: 20px !important;
+  svg {
+    padding: 3px !important;
+  }
+}
+
+.iconNoBorder {
+  margin: 0 var(--spacing-small) !important;
+}
+
+.defaultState {
+  border-radius: 10px;
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.module.scss.d.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.module.scss.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly defaultState: string
+  readonly editIcon: string
+  readonly iconNoBorder: string
+}
+export default styles

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.tsx
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { noop } from 'lodash-es'
+import cx from 'classnames'
+import { Icon } from '@harness/icons'
+import { FontVariation } from '@harness/design-system'
+import type { StepTitleInterface } from './StepTitle.types'
+import { getStateByStatus } from './StepTitle.utils'
+import { StepStatus } from '../../Step.constants'
+import { Text, Layout } from '../../../../../../'
+import css from './StepTitle.module.css'
+
+export const StepTitle = ({
+  step,
+  index,
+  isCurrent,
+  stepStatus,
+  onClick,
+  isOptional,
+  hideTitle
+}: StepTitleInterface): JSX.Element => {
+  const isErrorOrSuccess = stepStatus !== StepStatus.INCONCLUSIVE
+  const { icon, labelColor, iconColor, cursor } = getStateByStatus(stepStatus)
+  return (
+    <Layout.Vertical spacing="small">
+      <Layout.Horizontal
+        data-testid={`steptitle_${step.id}`}
+        style={{ cursor: isErrorOrSuccess ? 'pointer' : cursor }}
+        key={`${step.id}_horizontal`}
+        onClick={() => (isErrorOrSuccess ? onClick(index) : noop)}
+        flex={{ alignItems: 'center', justifyContent: 'start' }}>
+        {isCurrent ? (
+          <Icon
+            name={isErrorOrSuccess ? icon : 'Edit'}
+            size={isErrorOrSuccess ? 20 : 16}
+            margin="small"
+            color={iconColor}
+            className={cx(css.iconNoBorder, {
+              [css.editIcon]: !isErrorOrSuccess
+            })}
+          />
+        ) : (
+          <Icon
+            name={icon}
+            size={20}
+            margin="small"
+            color={iconColor}
+            className={cx(css.iconNoBorder, !isErrorOrSuccess && css.defaultState)}
+          />
+        )}
+        {!hideTitle && (
+          <Text font={{ variation: FontVariation.H5 }} color={labelColor}>
+            {step.title} {isOptional && '(Optional)'}
+          </Text>
+        )}
+      </Layout.Horizontal>
+    </Layout.Vertical>
+  )
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.types.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import type { StepStatusType } from '../../Step.types'
+import { StepDetailsInterface } from '../../../../Stepper.types'
+
+export interface StepTitleInterface {
+  step: StepDetailsInterface
+  index: number
+  isCurrent: boolean
+  stepStatus: StepStatusType
+  onClick: (index: number) => void
+  isOptional?: boolean
+  hideTitle?: boolean
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.utils.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.utils.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import { IconName } from '@harness/icons'
+import { StepStatus } from '../../Step.constants'
+import type { StepStatusType } from '../../Step.types'
+import { DefaultState, SuccessState, ErrorState } from './StepTitle.constants'
+
+export const getStateByStatus = (
+  stepStatus: StepStatusType
+): {
+  icon: IconName
+  cursor: string
+  iconColor: string
+  labelColor: string
+} => {
+  switch (stepStatus) {
+    case StepStatus.ERROR:
+      return {
+        icon: ErrorState.icon as IconName,
+        cursor: ErrorState.cursor,
+        iconColor: ErrorState.iconColor,
+        labelColor: ErrorState.labelColor
+      }
+    case StepStatus.SUCCESS:
+      return {
+        icon: SuccessState.icon as IconName,
+        cursor: SuccessState.cursor,
+        iconColor: SuccessState.iconColor,
+        labelColor: SuccessState.labelColor
+      }
+    case StepStatus.INCONCLUSIVE:
+    default:
+      return {
+        icon: DefaultState.icon as IconName,
+        cursor: DefaultState.cursor,
+        iconColor: DefaultState.iconColor,
+        labelColor: DefaultState.labelColor
+      }
+  }
+}

--- a/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.utils.ts
+++ b/packages/uicore/src/components/Stepper/components/Step/components/StepTitle/StepTitle.utils.ts
@@ -36,7 +36,7 @@ export const getStateByStatus = (
     case StepStatus.INCONCLUSIVE:
     default:
       return {
-        icon: DefaultState.icon as IconName,
+        icon: DefaultState.icon,
         cursor: DefaultState.cursor,
         iconColor: DefaultState.iconColor,
         labelColor: DefaultState.labelColor


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

<img width="1102" alt="Screenshot 2023-10-28 at 4 36 57 PM" src="https://github.com/harness/uicore/assets/81554936/c06f9aeb-d7db-44ab-8c6e-1087e116f89d">
<img width="1104" alt="Screenshot 2023-10-28 at 4 36 47 PM" src="https://github.com/harness/uicore/assets/81554936/b2744dde-9452-4337-8cb1-0bc0c09ceefd">
<img width="1147" alt="Screenshot 2023-10-28 at 4 36 36 PM" src="https://github.com/harness/uicore/assets/81554936/094b7493-2513-45a9-8ca1-0854c8183415">



- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
