### PR TITLE
fix: [CDS-80179]: add abort error in IGNORES_ERRORS

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.154.1",
+  "version": "3.154.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/utils/errorUtils.ts
+++ b/packages/uicore/src/utils/errorUtils.ts
@@ -13,7 +13,8 @@ const IGNORED_ERRORS = [
   'Failed to fetch: 504 Gateway Timeout',
   "Failed to fetch: Failed to execute 'fetch' on 'Window': The user aborted a request.",
   'Failed to fetch: The operation was aborted.',
-  'Failed to fetch: Fetch is aborted'
+  'Failed to fetch: Fetch is aborted',
+  'Failed to fetch: signal is aborted without reason'
 ]
 
 export function shouldShowError(e: any): boolean {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Adds **`Failed to fetch: signal is aborted without reason`** to **IGNORED_ERRORS**

This error was recently introduced in Apollo Client 3.7.4 

<img width="444" alt="image" src="https://github.com/harness/uicore/assets/100121280/9a1d981b-466e-44d8-a212-6e1d0f37faf9">




- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
