### PR TITLE
fix: [CDS-81020]: Fix ModalDialog OverlaySinner

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.154.2",
+  "version": "3.154.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.css
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.css
@@ -22,14 +22,19 @@
     'footer';
 }
 
-.overlayContainer {
-  overflow: auto;
-  pointer-events: none;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-  &::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
+.spinnerContainer {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.2);
+  -webkit-transition: 0.5s ease;
+  transition: 0.5s ease;
+  height: 100%;
+  width: 100%;
+  z-index: 15;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .noHeader.noFooter .body {

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -6,12 +6,11 @@
  */
 
 import React, { FC, ReactNode, useCallback, useEffect, useRef, useState, useMemo } from 'react'
-import { Dialog, IDialogProps } from '@blueprintjs/core'
+import { Dialog, IDialogProps, Spinner } from '@blueprintjs/core'
 import cx from 'classnames'
 import { isFunction } from 'lodash-es'
 import { FontVariation } from '@harness/design-system'
 import { Heading } from '../Heading/Heading'
-import { OverlaySpinner } from '../OverlaySpinner/OverlaySpinner'
 import { Button, ButtonVariation } from '../Button/Button'
 
 import css from './ModalDialog.css'
@@ -199,12 +198,11 @@ export const ModalDialog: FC<ModalDialogProps> = ({
       className={cx(className, css.container, ...modifiers)}
       style={style}
       {...dialogProps}>
-      {showOverlay ? (
-        <OverlaySpinner className={css.overlayContainer} show={true}>
-          {modalContent}
-        </OverlaySpinner>
-      ) : (
-        modalContent
+      {modalContent}
+      {showOverlay && (
+        <div className={css.spinnerContainer}>
+          <Spinner />
+        </div>
       )}
     </Dialog>
   )


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

**Issue:** modalContent unmount when showOverlay is true. This led to loss of data for modalContent

**Fix:** Do not unmount modalContent on change of showOverlay

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
