### PR TITLE
fix: [PL-42962]: add onQueryChange in Dropdown component

### DIFF
--- a/packages/uicore/src/components/DropDown/DropDown.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.tsx
@@ -175,6 +175,7 @@ export const DropDown: FC<DropDownProps> = props => {
     debounce(query => {
       if (Array.isArray(items)) {
         setDropDownItems(items.filter(item => item.label.toLowerCase().includes(query.toLowerCase())))
+        onQueryChange?.(query)
       } else if (typeof items === 'function') {
         onQueryChange?.(query)
       }


### PR DESCRIPTION
Issue - `onQueryChange` doesnt return any response when utlised in harness-core-ui when items passed is an array.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
