### PR TITLE
feat: [FFM-10188]: multiselectdropdown prop

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.154.7",
+  "version": "3.155.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
@@ -112,7 +112,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
 
   const onSearchChange = useCallback(
     (newQuery: string) => {
-      if (expandingSearchInputProps && 'onChange' in expandingSearchInputProps) {
+      if (expandingSearchInputProps?.onChange) {
         expandingSearchInputProps.onChange(newQuery)
       }
       setQuery(newQuery)

--- a/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/MultiSelectDropDown.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Popover, Spinner, Menu } from '@blueprintjs/core'
 import {
   QueryList,
@@ -25,7 +25,7 @@ import { Text } from '../Text/Text'
 import { StyledProps } from '@harness/design-system'
 import { Checkbox } from '../Checkbox/Checkbox'
 import { SelectOption } from '../Select/Select'
-import { ExpandingSearchInputWithRef } from '../ExpandingSearchInput/ExpandingSearchInput'
+import { ExpandingSearchInputWithRef, ExpandingSearchInputProps } from '../ExpandingSearchInput/ExpandingSearchInput'
 
 type Props = IQueryListProps<MultiSelectOption>
 
@@ -51,6 +51,7 @@ export interface MultiSelectDropDownProps
   hideItemCount?: boolean
   allowSearch?: boolean
   onPopoverClose?(opts: MultiSelectOption[]): void
+  expandingSearchInputProps?: ExpandingSearchInputProps
 }
 
 /**
@@ -76,6 +77,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
     hideItemCount,
     allowSearch = false,
     onPopoverClose,
+    expandingSearchInputProps,
     ...rest
   } = props
   const [query, setQuery] = React.useState<string>('')
@@ -84,7 +86,7 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
   const [loading, setLoading] = React.useState<boolean>(false)
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (Array.isArray(items)) {
       setDropDownItems([...items])
     } else if (typeof items === 'function') {
@@ -102,11 +104,21 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
     }
   }, [JSON.stringify(items)])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (Array.isArray(value)) {
       setSelectedItems(value)
     }
   }, [value])
+
+  const onSearchChange = useCallback(
+    (newQuery: string) => {
+      if (expandingSearchInputProps && 'onChange' in expandingSearchInputProps) {
+        expandingSearchInputProps.onChange(newQuery)
+      }
+      setQuery(newQuery)
+    },
+    [expandingSearchInputProps]
+  )
 
   // to filter out the options based on search
   const filterItems = (itemsToRender: SelectOption[]) => {
@@ -189,7 +201,9 @@ export function MultiSelectDropDown(props: MultiSelectDropDownProps): React.Reac
           <Icon name="main-chevron-down" size={8} color={Color.GREY_400} />
         </Layout.Horizontal>
         <React.Fragment>
-          {allowSearch && <ExpandingSearchInputWithRef onChange={setQuery} alwaysExpanded />}
+          {allowSearch && (
+            <ExpandingSearchInputWithRef alwaysExpanded {...expandingSearchInputProps} onChange={onSearchChange} />
+          )}
           {listProps.itemList
             ? React.cloneElement(listProps.itemList as React.ReactElement, {
                 className: css.menu

--- a/packages/uicore/src/components/MultiSelectDropDown/__tests__/MultiSelectDropdown.test.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/__tests__/MultiSelectDropdown.test.tsx
@@ -40,40 +40,6 @@ describe('MultiSelectDropDown', () => {
     expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
   })
 
-  test('it should call ExpandingSearchInputProps onChange when it is defined instead of MultiSelectDropDown onChange', async () => {
-    const onSearchChange = jest.fn()
-    const onChange = jest.fn()
-
-    renderComponent({
-      items: [
-        { label: 'value1', value: 'value1id' },
-        { label: 'value2', value: 'value2id' }
-      ],
-      allowSearch: true,
-      expandingSearchInputProps: {
-        onChange: onSearchChange
-      },
-      usePortal: true,
-      onChange: onChange
-    })
-
-    userEvent.click(screen.getByText('Select'))
-
-    const dropdownSearchbox = await screen.findByRole('searchbox')
-
-    const dropdownInput = 'value1'
-
-    await waitFor(() => expect(onSearchChange).not.toHaveBeenCalled())
-    await waitFor(() => expect(onChange).not.toHaveBeenCalled())
-
-    userEvent.type(dropdownSearchbox, dropdownInput)
-
-    expect(dropdownSearchbox).toHaveValue(dropdownInput)
-
-    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith('value1'))
-    await waitFor(() => expect(onChange).not.toHaveBeenCalled())
-  })
-
   test('it should call MultiSelectDropDown onChange when ExpandingSearchInputProps is undefined ', async () => {
     const onChange = jest.fn()
 
@@ -90,18 +56,18 @@ describe('MultiSelectDropDown', () => {
 
     userEvent.click(screen.getByText('Select'))
 
+    expect(screen.getByRole('checkbox', { name: 'value1' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'value2' })).toBeInTheDocument()
+
     const dropdownSearchbox = await screen.findByRole('searchbox')
 
     const dropdownInput = 'value1'
-
-    await waitFor(() => expect(onChange).not.toHaveBeenCalled())
 
     userEvent.type(dropdownSearchbox, dropdownInput)
 
     expect(dropdownSearchbox).toHaveValue(dropdownInput)
 
-    // await waitFor(() => expect(onChange).toHaveBeenCalled())
-
+    expect(await screen.findByText(dropdownInput)).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText('value2')).not.toBeInTheDocument())
   })
 })

--- a/packages/uicore/src/components/MultiSelectDropDown/__tests__/MultiSelectDropdown.test.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/__tests__/MultiSelectDropdown.test.tsx
@@ -40,18 +40,14 @@ describe('MultiSelectDropDown', () => {
     expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
   })
 
-  test('it should call MultiSelectDropDown onChange when ExpandingSearchInputProps is undefined ', async () => {
-    const onChange = jest.fn()
-
+  test('it should filter out non-matching results when a user performs a search', async () => {
     renderComponent({
       items: [
         { label: 'value1', value: 'value1id' },
         { label: 'value2', value: 'value2id' }
       ],
       allowSearch: true,
-      usePortal: true,
-      onChange: onChange,
-      expandingSearchInputProps: undefined
+      usePortal: true
     })
 
     userEvent.click(screen.getByText('Select'))
@@ -69,5 +65,35 @@ describe('MultiSelectDropDown', () => {
 
     expect(await screen.findByText(dropdownInput)).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText('value2')).not.toBeInTheDocument())
+  })
+
+  test('it should call ExpandingSearchInputProps onChange with the correct value when user performs a search when that prop is defined', async () => {
+    const onSearchChange = jest.fn()
+
+    renderComponent({
+      items: [
+        { label: 'value1', value: 'value1id' },
+        { label: 'value2', value: 'value2id' }
+      ],
+      allowSearch: true,
+      expandingSearchInputProps: {
+        onChange: onSearchChange
+      },
+      usePortal: true
+    })
+
+    userEvent.click(screen.getByText('Select'))
+
+    const dropdownSearchbox = await screen.findByRole('searchbox')
+
+    const dropdownInput = 'value1'
+
+    await waitFor(() => expect(onSearchChange).not.toHaveBeenCalled())
+
+    userEvent.type(dropdownSearchbox, dropdownInput)
+
+    expect(dropdownSearchbox).toHaveValue(dropdownInput)
+
+    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith(dropdownInput))
   })
 })

--- a/packages/uicore/src/components/MultiSelectDropDown/__tests__/MultiSelectDropdown.test.tsx
+++ b/packages/uicore/src/components/MultiSelectDropDown/__tests__/MultiSelectDropdown.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render, screen, RenderResult, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MultiSelectDropDown, MultiSelectDropDownProps } from '../MultiSelectDropDown'
+
+const renderComponent = (props: Partial<MultiSelectDropDownProps> = {}): RenderResult =>
+  render(<MultiSelectDropDown items={[]} {...props} />)
+
+describe('MultiSelectDropDown', () => {
+  test('it should display items passed through as props', async () => {
+    renderComponent({
+      items: [
+        { label: 'value1', value: 'value1id' },
+        { label: 'value2', value: 'value2id' }
+      ],
+      allowSearch: true
+    })
+
+    userEvent.click(screen.getByText('Select'))
+
+    expect(screen.getByRole('checkbox', { name: 'value1' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'value2' })).toBeInTheDocument()
+  })
+
+  test('it should not display ExpandingSearchInput if allowSearch prop is false', async () => {
+    renderComponent({
+      items: [],
+      allowSearch: false
+    })
+
+    userEvent.click(screen.getByText('Select'))
+
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument()
+  })
+
+  test('it should call ExpandingSearchInputProps onChange when it is defined instead of MultiSelectDropDown onChange', async () => {
+    const onSearchChange = jest.fn()
+    const onChange = jest.fn()
+
+    renderComponent({
+      items: [
+        { label: 'value1', value: 'value1id' },
+        { label: 'value2', value: 'value2id' }
+      ],
+      allowSearch: true,
+      expandingSearchInputProps: {
+        onChange: onSearchChange
+      },
+      usePortal: true,
+      onChange: onChange
+    })
+
+    userEvent.click(screen.getByText('Select'))
+
+    const dropdownSearchbox = await screen.findByRole('searchbox')
+
+    const dropdownInput = 'value1'
+
+    await waitFor(() => expect(onSearchChange).not.toHaveBeenCalled())
+    await waitFor(() => expect(onChange).not.toHaveBeenCalled())
+
+    userEvent.type(dropdownSearchbox, dropdownInput)
+
+    expect(dropdownSearchbox).toHaveValue(dropdownInput)
+
+    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith('value1'))
+    await waitFor(() => expect(onChange).not.toHaveBeenCalled())
+  })
+
+  test('it should call MultiSelectDropDown onChange when ExpandingSearchInputProps is undefined ', async () => {
+    const onChange = jest.fn()
+
+    renderComponent({
+      items: [
+        { label: 'value1', value: 'value1id' },
+        { label: 'value2', value: 'value2id' }
+      ],
+      allowSearch: true,
+      usePortal: true,
+      onChange: onChange,
+      expandingSearchInputProps: undefined
+    })
+
+    userEvent.click(screen.getByText('Select'))
+
+    const dropdownSearchbox = await screen.findByRole('searchbox')
+
+    const dropdownInput = 'value1'
+
+    await waitFor(() => expect(onChange).not.toHaveBeenCalled())
+
+    userEvent.type(dropdownSearchbox, dropdownInput)
+
+    expect(dropdownSearchbox).toHaveValue(dropdownInput)
+
+    // await waitFor(() => expect(onChange).toHaveBeenCalled())
+
+    await waitFor(() => expect(screen.queryByText('value2')).not.toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
This PR adds a new optional prop into the ExpandingSearchInput component within the MultiSelectDropdown component. This should allow the ExpandingSearchInput to make searches via api requests 

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
