### PR TITLE
fix: [CDS-88240]: added classname prop in accordion panel

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.156.0",
+  "version": "3.157.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -19,6 +19,7 @@ export interface AccordionPanelProps {
   summary: React.ReactNode
   addDomId?: boolean
   disabled?: boolean
+  className?: string
 }
 
 export interface AccordionPanelInternalProps extends Omit<AccordionProps, 'children' | 'activeId' | 'className'> {
@@ -44,7 +45,8 @@ function AccordionPanel(
     panelClassName,
     summaryClassName,
     detailsClassName,
-    chevronClassName
+    chevronClassName,
+    className
   } = props
 
   return (
@@ -52,7 +54,7 @@ function AccordionPanel(
       ref={ref}
       data-testid={`${id}-panel`}
       data-disabled={disabled}
-      className={cx(css.panel, panelClassName)}
+      className={cx(css.panel, panelClassName, className)}
       data-open={isOpen}
       id={addDomId ? `${id}-panel` : undefined}>
       <div data-testid={`${id}-summary`} onClick={togglePanel} className={cx(css.summary, summaryClassName)}>


### PR DESCRIPTION
Added className in panel props, it's required to make changes on module panel in the ModuleAccordion component of new nav. 

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
