### PR TITLE
fix: [PL-43925]: Prevent default reset-to-top for MultiSelect

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.157.0",
+  "version": "3.158.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -584,8 +584,11 @@ const MultiSelect = (props: MultiSelectProps & FormikContextProps<any>) => {
     inline = formik?.inline,
     tagInputProps,
     placeholder,
-    multiSelectProps,
     onChange,
+    multiSelectProps: { resetOnQuery = false, resetOnSelect = false, ...otherMultiSelectProps } = {
+      resetOnQuery: false,
+      resetOnSelect: false
+    },
     ...rest
   } = restProps
 
@@ -612,8 +615,9 @@ const MultiSelect = (props: MultiSelectProps & FormikContextProps<any>) => {
           intent,
           disabled: disabled
         }}
-        resetOnSelect={true}
-        {...multiSelectProps}
+        resetOnSelect={resetOnSelect}
+        resetOnQuery={resetOnQuery}
+        {...otherMultiSelectProps}
         items={items}
         value={Array.isArray(formikValue) ? formikValue : []}
         onChange={(items: MultiSelectOption[]) => {


### PR DESCRIPTION
Jira: https://harness.atlassian.net/browse/PL-43925
Prevent default reset-to-top for MultiSelect

#### Screenshots


BEFORE:

https://github.com/harness/harness-core-ui/assets/96057095/cd7e6dbe-f873-49ae-a485-93d052e29c66


AFTER:

https://github.com/harness/harness-core-ui/assets/96057095/3fa55cd3-f55d-45f4-8397-92961c53e2cb


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
