### PR TITLE
fix: [chore/CDS-85482]: add support for title and className in the tagPopover component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.158.0",
+  "version": "3.158.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TagsPopover/TagsPopover.tsx
+++ b/packages/uicore/src/components/TagsPopover/TagsPopover.tsx
@@ -21,10 +21,12 @@ export interface ListTagsProps {
   target?: React.ReactElement
   popoverProps?: IPopoverProps
   iconProps?: Omit<IconProps, 'name'>
+  tagsTitle?: string
+  containerClassName?: string
 }
 
 export const TagsPopover: React.FC<ListTagsProps> = props => {
-  const { tags, target, tagClassName, popoverProps, iconProps, className } = props
+  const { tags, target, tagClassName, popoverProps, iconProps, className, tagsTitle, containerClassName } = props
   return (
     <Popover interactionKind={PopoverInteractionKind.HOVER} {...popoverProps}>
       {target || (
@@ -33,8 +35,8 @@ export const TagsPopover: React.FC<ListTagsProps> = props => {
           <Text>{Object.keys(tags).length}</Text>
         </Layout.Horizontal>
       )}
-      <Container padding="small">
-        <Text font={{ size: 'small', weight: 'bold' }}>{i18n.tags}</Text>
+      <Container padding="small" className={containerClassName}>
+        <Text font={{ size: 'small', weight: 'bold' }}>{tagsTitle || i18n.tags}</Text>
         <Container className={css.tagsPopover}>
           {Object.keys(tags).map(key => {
             const value = tags[key]


### PR DESCRIPTION
…gPopover component

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
