### PR TITLE
feat: [CDS-88611]: Added shouldRender property in accordion panel

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.158.1",
+  "version": "3.159.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -20,6 +20,7 @@ export interface AccordionPanelProps {
   addDomId?: boolean
   disabled?: boolean
   className?: string
+  shouldRender?: () => boolean
 }
 
 export interface AccordionPanelInternalProps extends Omit<AccordionProps, 'children' | 'activeId' | 'className'> {
@@ -46,8 +47,13 @@ function AccordionPanel(
     summaryClassName,
     detailsClassName,
     chevronClassName,
-    className
+    className,
+    shouldRender
   } = props
+
+  if (!shouldRender?.()) {
+    return <></>
+  }
 
   return (
     <div

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -20,7 +20,7 @@ export interface AccordionPanelProps {
   addDomId?: boolean
   disabled?: boolean
   className?: string
-  shouldRender?: () => boolean
+  shouldRender?: boolean | (() => boolean)
 }
 
 export interface AccordionPanelInternalProps extends Omit<AccordionProps, 'children' | 'activeId' | 'className'> {
@@ -33,7 +33,7 @@ export const AccordionPanelWithRef = React.forwardRef(AccordionPanel)
 function AccordionPanel(
   props: AccordionPanelProps & AccordionPanelInternalProps,
   ref: React.Ref<HTMLDivElement>
-): React.ReactElement {
+): React.ReactElement | null {
   const {
     summary,
     details,
@@ -51,8 +51,12 @@ function AccordionPanel(
     shouldRender
   } = props
 
-  if (shouldRender && !shouldRender?.()) {
-    return <></>
+  if (typeof shouldRender === 'boolean' && !shouldRender) {
+    return null
+  }
+
+  if (typeof shouldRender === 'function' && !shouldRender?.()) {
+    return null
   }
 
   return (

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -51,7 +51,7 @@ function AccordionPanel(
     shouldRender
   } = props
 
-  if (!shouldRender?.()) {
+  if (shouldRender && !shouldRender?.()) {
     return <></>
   }
 


### PR DESCRIPTION
Accordion component expects child to be Accordion.Panel component always. We can't render any other component as child. 

This causes the issue when rendering the Accordion.Panel component conditionally. Adding shouldRender property to show/hide the Accordion.Panel component




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
