### PR TITLE
feat: [CDS-89316]: Using harness primary color for toast variant primary

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.160.0",
+  "version": "3.160.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/hooks/useToaster/useToaster.css
+++ b/packages/uicore/src/hooks/useToaster/useToaster.css
@@ -37,4 +37,7 @@
   :global(.bp3-toast.bp3-intent-success) {
     background-color: var(--green-600);
   }
+  :global(.bp3-toast.bp3-intent-primary) {
+    background-color: var(--primary-7);
+  }
 }


### PR DESCRIPTION
Added harness primary color for toast variant primary, the default blueprint color was being used earlier

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
