### PR TITLE
fix: [CDS-93893]: Fixing scroll reset for multiSelect after selection

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.160.1",
+  "version": "3.160.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -63,6 +63,7 @@ export const Basic: Story<MultiSelectProps> = args => {
       onChange={items => {
         setValue(items)
       }}
+      avoidResetOnSelect={true}
       {...argsCopy}
     />
   )

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -40,6 +40,7 @@ export interface MultiSelectProps
     | 'onActiveItemChange'
   > {
   itemRender?: Props['itemRenderer']
+  avoidResetOnSelect?: boolean // Once verified, we can replace it with BP resetOnSelect to make new behavior as default
   onChange?(opts: MultiSelectOption[]): void
   value?: MultiSelectOption[]
   items: Props['items'] | (() => Promise<Props['items']>)
@@ -67,6 +68,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
     disabled,
     popoverClassName,
     allowCommaSeparatedList,
+    avoidResetOnSelect = false || props?.resetOnSelect === false, // Keeping backward compatibility
     ...rest
   } = props
   const [query, setQuery] = React.useState(props.query || '')
@@ -96,7 +98,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         } else {
           onChange(selectedItems.concat(item))
         }
-        setQuery('')
+        !avoidResetOnSelect && setQuery('')
       } else {
         onChange(selectedItems.filter((_, i) => i !== index))
       }
@@ -254,7 +256,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         }
       }}
       query={query}
-      resetOnQuery={false}
+      resetOnSelect={!avoidResetOnSelect}
       noResults={<NoMatch />}
       popoverProps={{
         targetTagName: 'div',

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -254,6 +254,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         }
       }}
       query={query}
+      resetOnQuery={false}
       noResults={<NoMatch />}
       popoverProps={{
         targetTagName: 'div',

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -40,7 +40,7 @@ export interface MultiSelectProps
     | 'onActiveItemChange'
   > {
   itemRender?: Props['itemRenderer']
-  avoidResetOnSelect?: boolean // Once verified, we can replace it with BP resetOnSelect to make new behavior as default
+  avoidResetOnSelect?: boolean // This will prevent scroll reset to top
   onChange?(opts: MultiSelectOption[]): void
   value?: MultiSelectOption[]
   items: Props['items'] | (() => Promise<Props['items']>)
@@ -256,7 +256,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         }
       }}
       query={query}
-      resetOnSelect={!avoidResetOnSelect}
+      resetOnQuery={!avoidResetOnSelect}
       noResults={<NoMatch />}
       popoverProps={{
         targetTagName: 'div',


### PR DESCRIPTION
**Issue:** 
Scroll was resetting to top after every selection . 
**Fix:** 
Fixed the scroll reset using resetOnQuery : false . 

Have kept the changes backward compatible and right now consumer has to use the prop { avoidResetOnSelect: true} . 
Once these changes will be tested and verified  for `MultiSelectVariableAllowedValues` component we will ask PM whether to make this itself a default behaviour or not, for all multi-select.

**Use case tested :** 

- Selection change : working
- Search by query change : working

Changes is tested with NGUI using yalc for which screen recordings are added.

**Current behaviour with scroll reset** 

https://github.com/harness/uicore/assets/63278928/76b9971c-089e-4c63-8648-0278c0f1d120




**After fix:** 

https://github.com/harness/uicore/assets/63278928/ff4a9f8c-04e9-47eb-9e54-cdea43c8811b


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
