### PR TITLE
fix: [CDS-93893]: Ignoring the reset if allowCreatingNewItems is used

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.160.2",
+  "version": "3.160.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -100,7 +100,10 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         } else {
           onChange(selectedItems.concat(item))
         }
-        ;(rest?.allowCreatingNewItems || !avoidResetOnSelect) && setQuery('')
+
+        if (rest?.allowCreatingNewItems || !avoidResetOnSelect) {
+          setQuery('')
+        }
       } else {
         onChange(selectedItems.filter((_, i) => i !== index))
       }

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -40,7 +40,9 @@ export interface MultiSelectProps
     | 'onActiveItemChange'
   > {
   itemRender?: Props['itemRenderer']
-  avoidResetOnSelect?: boolean // This will prevent scroll reset to top
+  /** Avoid resetting the query and scroll to the top upon selection.
+   * Will be ignored with allowCreatingNewItems as query must ne reset. */
+  avoidResetOnSelect?: boolean
   onChange?(opts: MultiSelectOption[]): void
   value?: MultiSelectOption[]
   items: Props['items'] | (() => Promise<Props['items']>)
@@ -68,7 +70,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
     disabled,
     popoverClassName,
     allowCommaSeparatedList,
-    avoidResetOnSelect = false || props?.resetOnSelect === false, // Keeping backward compatibility
+    avoidResetOnSelect = props?.resetOnSelect === false, // Keeping backward compatibility
     ...rest
   } = props
   const [query, setQuery] = React.useState(props.query || '')
@@ -98,7 +100,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         } else {
           onChange(selectedItems.concat(item))
         }
-        !avoidResetOnSelect && setQuery('')
+        ;(rest?.allowCreatingNewItems || !avoidResetOnSelect) && setQuery('')
       } else {
         onChange(selectedItems.filter((_, i) => i !== index))
       }
@@ -256,7 +258,7 @@ export function MultiSelect(props: MultiSelectProps): React.ReactElement {
         }
       }}
       query={query}
-      resetOnQuery={!avoidResetOnSelect}
+      resetOnQuery={rest?.allowCreatingNewItems || !avoidResetOnSelect}
       noResults={<NoMatch />}
       popoverProps={{
         targetTagName: 'div',

--- a/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uicore/src/components/MultiSelect/MultiSelect.tsx
@@ -41,7 +41,7 @@ export interface MultiSelectProps
   > {
   itemRender?: Props['itemRenderer']
   /** Avoid resetting the query and scroll to the top upon selection.
-   * Will be ignored with allowCreatingNewItems as query must ne reset. */
+   * Will be ignored with allowCreatingNewItems as query must be reset after each creation. */
   avoidResetOnSelect?: boolean
   onChange?(opts: MultiSelectOption[]): void
   value?: MultiSelectOption[]


### PR DESCRIPTION
Follow up PR of https://github.com/harness/uicore/pull/1261 

We have to reset the query for allowCreatingNewItems. 

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
