### PR TITLE
fix: [CDS-93392]: prevent blueprintjs warning

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.160.3",
+  "version": "3.160.4",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Dialog/Dialog.test.tsx
+++ b/packages/uicore/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Dialog } from './Dialog'
+
+describe('<Dialog /> tests', () => {
+  test('ignore isCloseButtonShown when title is not set', () => {
+    const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => undefined)
+
+    render(<Dialog isOpen={true} />)
+
+    expect(warnSpy).not.toBeCalled()
+
+    warnSpy.mockRestore()
+  })
+})

--- a/packages/uicore/src/components/Dialog/Dialog.tsx
+++ b/packages/uicore/src/components/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react'
 import cx from 'classnames'
+import { isNil } from 'lodash-es'
 import { Container, Icon } from '../..'
 import { Dialog as BluePrintDialog, IDialogProps } from '@blueprintjs/core'
 import css from './Dialog.css'
@@ -26,12 +27,15 @@ const defaultProps = {
 }
 
 export function Dialog(props: DialogProps): React.ReactElement {
+  // blueprint throws a warning when isCloseButtonShown is set and title is not set
+  const isCloseButtonShown = isNil(props.title) ? undefined : false
+
   return (
     <BluePrintDialog
       {...defaultProps}
       {...props}
       className={cx(css.dialog, props.className)}
-      isCloseButtonShown={false}>
+      isCloseButtonShown={isCloseButtonShown}>
       <Icon name="Stroke" size={15} onClick={props.onClose} className={css.close} />
       <Container padding="none" className={cx(css.children, props.chidrenClassName)}>
         {props.children}


### PR DESCRIPTION
This fix prevents warning:

<img width="610" alt="Screenshot 2024-03-25 at 18 03 10" src="https://github.com/harness/uicore/assets/69592850/1a1bd5c8-2af2-4ce9-b8d4-f5ad0ed5f9c3">


```[Blueprint] <Dialog> isCloseButtonShown prop is ignored if title is omitted. ```




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
