### PR TITLE
fix: Fix wrong CSS targeting in SplitButton

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/uicore",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/SplitButton/SplitButton.css
+++ b/packages/uicore/src/components/SplitButton/SplitButton.css
@@ -55,11 +55,11 @@
       padding-left: 0 !important;
     }
 
-    .border-left-0.Button--button[class*='bp3-button'] {
+    .border-left-0[class*='Button--button'][class*='bp3-button'] {
       border-left: none !important;
     }
 
-    .border-right-0.Button--button[class*='bp3-button'] {
+    .border-right-0[class*='Button--button'][class*='bp3-button'] {
       border-right: none !important;
     }
   }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
