### PR TITLE
fix: [PIPE-18595]: hide toast if message is empty string

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.164.0",
+  "version": "3.164.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/hooks/useToaster/useToaster.tsx
+++ b/packages/uicore/src/hooks/useToaster/useToaster.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ReactNode } from 'react'
-import { Toaster, Position, IToaster, Intent } from '@blueprintjs/core'
+import { Toaster, Position, IToaster, Intent, IToastProps } from '@blueprintjs/core'
 import css from './useToaster.css'
 
 const toaster = Toaster.create({
@@ -21,20 +21,26 @@ export interface ToasterProps extends IToaster {
   showPrimary: (message: string | ReactNode, timeout?: number, key?: string) => void
 }
 
+const showToast = (options: IToastProps, key?: string): void => {
+  if (options.message !== '') {
+    toaster.show(options, key)
+  }
+}
+
 const showSuccess = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  toaster.show({ message, intent: Intent.SUCCESS, icon: 'tick', timeout }, key)
+  showToast({ message, intent: Intent.SUCCESS, icon: 'tick', timeout }, key)
 }
 
 const showError = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  toaster.show({ message, intent: Intent.DANGER, icon: 'warning-sign', timeout }, key)
+  showToast({ message, intent: Intent.DANGER, icon: 'warning-sign', timeout }, key)
 }
 
 const showWarning = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  toaster.show({ message, intent: Intent.WARNING, icon: 'error', timeout }, key)
+  showToast({ message, intent: Intent.WARNING, icon: 'error', timeout }, key)
 }
 
 const showPrimary = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  toaster.show({ message, intent: Intent.PRIMARY, timeout }, key)
+  showToast({ message, intent: Intent.PRIMARY, timeout }, key)
 }
 
 export function useToaster(): ToasterProps {


### PR DESCRIPTION
- Hides toast banner for empty message

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
