### PR TITLE
chore: [CDS-95922]: Optimized button rendering logic with useCallback

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.164.1",
+  "version": "3.164.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -201,6 +201,45 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
     }
   }, [multitypeInputValue])
 
+  const renderButtonType = useCallback(() => {
+    if (!allowableTypes.length) return null
+
+    return (
+      <Button
+        noStyling
+        className={cx(mini ? css.miniBtn : css.btn, css[type], btnClassName)}
+        tooltip={
+          disabled ? undefined : (
+            <MultiTypeInputMenu i18n={i18n} onTypeSelect={switchType} allowedTypes={allowableTypes} />
+          )
+        }
+        onClick={ev => {
+          // if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
+          //   /*
+          //   PIE-1755
+          //   https://github.com/palantir/blueprint/issues/3856
+          //   Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
+          //   So checking the event pointer type, and stopping the propagation if not clicked by the user
+          //   */
+          //   ev.stopPropagation()
+          // }
+          ev.preventDefault()
+        }}
+        disabled={disabled}
+        tooltipProps={{
+          minimal: true,
+          position: Position.BOTTOM_RIGHT,
+          interactionKind: PopoverInteractionKind.CLICK,
+          popoverClassName: css.popover,
+          className: css.wrapper,
+          lazy: true
+        }}
+        data-testid="multi-type-button">
+        <Icon name={MultiTypeIcon[type]} size={MultiTypeIconSize[type]} />
+      </Button>
+    )
+  }, [allowableTypes, mini, css, type, btnClassName, disabled, i18n, switchType])
+
   return (
     <Layout.Horizontal
       className={cx(mini ? css.mini : css.main, {
@@ -271,40 +310,7 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
           textAreaClassName={textAreaInputClassName}
         />
       )}
-      {!allowableTypes.length ? null : (
-        <Button
-          noStyling
-          className={cx(mini ? css.miniBtn : css.btn, css[type], btnClassName)}
-          tooltip={
-            disabled ? undefined : (
-              <MultiTypeInputMenu i18n={i18n} onTypeSelect={switchType} allowedTypes={allowableTypes} />
-            )
-          }
-          onClick={ev => {
-            // if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
-            //   /*
-            //   PIE-1755
-            //   https://github.com/palantir/blueprint/issues/3856
-            //   Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
-            //   So checking the event pointer type, and stopping the propagation if not clicked by the user
-            //   */
-            //   ev.stopPropagation()
-            // }
-            ev.preventDefault()
-          }}
-          disabled={disabled}
-          tooltipProps={{
-            minimal: true,
-            position: Position.BOTTOM_RIGHT,
-            interactionKind: PopoverInteractionKind.CLICK,
-            popoverClassName: css.popover,
-            className: css.wrapper,
-            lazy: true
-          }}
-          data-testid="multi-type-button">
-          <Icon name={MultiTypeIcon[type]} size={MultiTypeIconSize[type]} />
-        </Button>
-      )}
+      {renderButtonType()}
     </Layout.Horizontal>
   )
 }

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -6,13 +6,11 @@
  */
 
 import React, { useState, useCallback, useMemo, useEffect, CSSProperties } from 'react'
-import { Button } from '../Button/Button'
 import { Select, SelectProps, SelectOption } from '../Select/Select'
 import { TextInput } from '../TextInput/TextInput'
 import { Layout, LayoutProps } from '../../layouts/Layout'
 import css from './MultiTypeInput.css'
-import { Icon } from '@harness/icons'
-import { Position, PopoverInteractionKind, IInputGroupProps, InputGroup, HTMLInputProps } from '@blueprintjs/core'
+import { IInputGroupProps, InputGroup, HTMLInputProps } from '@blueprintjs/core'
 import cx from 'classnames'
 import i18nBase from './MultiTypeInput.i18n'
 import { I18nResource } from '@harness/design-system'
@@ -22,15 +20,14 @@ import { ExpressionInput } from '../ExpressionInput/ExpressionInput'
 import {
   MultiTypeInputType,
   MultiTypeInputValue,
-  MultiTypeIcon,
-  MultiTypeIconSize,
   RUNTIME_INPUT_VALUE,
   EXPRESSION_INPUT_PLACEHOLDER,
   EXECUTION_TIME_INPUT_VALUE,
   REGEX_INPUT_PLACEHOLDER,
   RUNTIME_INPUT_V1_PREFIX
 } from './MultiTypeInputUtils'
-import { AllowedTypes, AllowedTypesWithExecutionTime, MultiTypeInputMenu } from './MultiTypeInputMenu'
+import { AllowedTypes, AllowedTypesWithExecutionTime } from './MultiTypeInputMenu'
+import TypeSelectorButton from './TypeSelectorButton'
 import { SelectWithSubmenu, SelectWithSubmenuProps } from '../SelectWithSubmenu/SelectWithSubmenu'
 import { SelectWithSubmenuV2, SelectWithSubmenuPropsV2 } from '../SelectWithSubmenu/SelectWithSubmenuV2'
 import { MultiSelectWithSubmenu, MultiSelectWithSubmenuProps } from '../MultiSelectWithSubmenu/MultiSelectWithSubmenu'
@@ -148,6 +145,7 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
     renderRuntimeInput,
     ...layoutProps
   } = props
+
   const i18n = useMemo(() => Object.assign({}, i18nBase, _i18n), [_i18n])
   const [type, setType] = useState<MultiTypeInputType>(getMultiTypeFromValue(value))
   const [mentionsType] = useState(`multi-type-input-${Utils.randomId()}`)
@@ -200,45 +198,6 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
       setType(multitypeInputValue)
     }
   }, [multitypeInputValue])
-
-  const renderButtonType = useCallback(() => {
-    if (!allowableTypes.length) return null
-
-    return (
-      <Button
-        noStyling
-        className={cx(mini ? css.miniBtn : css.btn, css[type], btnClassName)}
-        tooltip={
-          disabled ? undefined : (
-            <MultiTypeInputMenu i18n={i18n} onTypeSelect={switchType} allowedTypes={allowableTypes} />
-          )
-        }
-        onClick={ev => {
-          // if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
-          //   /*
-          //   PIE-1755
-          //   https://github.com/palantir/blueprint/issues/3856
-          //   Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
-          //   So checking the event pointer type, and stopping the propagation if not clicked by the user
-          //   */
-          //   ev.stopPropagation()
-          // }
-          ev.preventDefault()
-        }}
-        disabled={disabled}
-        tooltipProps={{
-          minimal: true,
-          position: Position.BOTTOM_RIGHT,
-          interactionKind: PopoverInteractionKind.CLICK,
-          popoverClassName: css.popover,
-          className: css.wrapper,
-          lazy: true
-        }}
-        data-testid="multi-type-button">
-        <Icon name={MultiTypeIcon[type]} size={MultiTypeIconSize[type]} />
-      </Button>
-    )
-  }, [allowableTypes, mini, css, type, btnClassName, disabled, i18n, switchType])
 
   return (
     <Layout.Horizontal
@@ -310,7 +269,15 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
           textAreaClassName={textAreaInputClassName}
         />
       )}
-      {renderButtonType()}
+      <TypeSelectorButton
+        allowableTypes={allowableTypes}
+        mini={mini}
+        type={type}
+        btnClassName={btnClassName}
+        disabled={disabled}
+        i18n={i18n}
+        switchType={switchType}
+      />
     </Layout.Horizontal>
   )
 }

--- a/packages/uicore/src/components/MultiTypeInput/TypeSelectorButton.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/TypeSelectorButton.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import cx from 'classnames'
+import { Icon } from '@harness/icons'
+import { I18nResource } from '@harness/design-system'
+import { Position, PopoverInteractionKind } from '@blueprintjs/core'
+import { Button } from '../Button/Button'
+import { MultiTypeIcon, MultiTypeIconSize, MultiTypeInputType } from './MultiTypeInputUtils'
+import { AllowedTypes, MultiTypeInputMenu } from './MultiTypeInputMenu'
+import css from './MultiTypeInput.css'
+
+interface RenderButtonTypeProps {
+  type: MultiTypeInputType
+  btnClassName: string
+  i18n: I18nResource
+  allowableTypes: AllowedTypes
+  disabled?: boolean
+  mini?: boolean
+  switchType: (newType: MultiTypeInputType) => void
+}
+const TypeSelectorButton = (props: RenderButtonTypeProps): React.ReactElement | null => {
+  const { allowableTypes, mini, type, btnClassName, disabled, i18n, switchType } = props
+  if (!allowableTypes.length) return null
+
+  return (
+    <Button
+      noStyling
+      className={cx(mini ? css.miniBtn : css.btn, css[type], btnClassName)}
+      tooltip={
+        disabled ? undefined : (
+          <MultiTypeInputMenu i18n={i18n} onTypeSelect={switchType} allowedTypes={allowableTypes} />
+        )
+      }
+      onClick={ev => {
+        // if ((ev.nativeEvent as PointerEvent).pointerType !== 'mouse') {
+        //   /*
+        //   PIE-1755
+        //   https://github.com/palantir/blueprint/issues/3856
+        //   Button attached next to an InputGroup triggers the click event when enter key is pressed while typing
+        //   So checking the event pointer type, and stopping the propagation if not clicked by the user
+        //   */
+        //   ev.stopPropagation()
+        // }
+        ev.preventDefault()
+      }}
+      disabled={disabled}
+      tooltipProps={{
+        minimal: true,
+        position: Position.BOTTOM_RIGHT,
+        interactionKind: PopoverInteractionKind.CLICK,
+        popoverClassName: css.popover,
+        className: css.wrapper,
+        lazy: true
+      }}
+      data-testid="multi-type-button">
+      <Icon name={MultiTypeIcon[type]} size={MultiTypeIconSize[type]} />
+    </Button>
+  )
+}
+
+export default TypeSelectorButton

--- a/packages/uicore/src/hooks/useToaster/useToaster.tsx
+++ b/packages/uicore/src/hooks/useToaster/useToaster.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ReactNode } from 'react'
-import { Toaster, Position, IToaster, Intent, IToastProps } from '@blueprintjs/core'
+import { Toaster, Position, IToaster, Intent } from '@blueprintjs/core'
 import css from './useToaster.css'
 
 const toaster = Toaster.create({
@@ -21,26 +21,20 @@ export interface ToasterProps extends IToaster {
   showPrimary: (message: string | ReactNode, timeout?: number, key?: string) => void
 }
 
-const showToast = (options: IToastProps, key?: string): void => {
-  if (options.message !== '') {
-    toaster.show(options, key)
-  }
-}
-
 const showSuccess = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  showToast({ message, intent: Intent.SUCCESS, icon: 'tick', timeout }, key)
+  toaster.show({ message, intent: Intent.SUCCESS, icon: 'tick', timeout }, key)
 }
 
 const showError = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  showToast({ message, intent: Intent.DANGER, icon: 'warning-sign', timeout }, key)
+  toaster.show({ message, intent: Intent.DANGER, icon: 'warning-sign', timeout }, key)
 }
 
 const showWarning = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  showToast({ message, intent: Intent.WARNING, icon: 'error', timeout }, key)
+  toaster.show({ message, intent: Intent.WARNING, icon: 'error', timeout }, key)
 }
 
 const showPrimary = (message: string | ReactNode, timeout?: number, key?: string): void => {
-  showToast({ message, intent: Intent.PRIMARY, timeout }, key)
+  toaster.show({ message, intent: Intent.PRIMARY, timeout }, key)
 }
 
 export function useToaster(): ToasterProps {


### PR DESCRIPTION
- During profiler investigation, that the button and SVG component are re-rendering due to 2 reasons

1. The parent component was re-rendered 
2. In most cases it was due to unrelated props changes in value, expressions, etc.

- For a pipeline with many inputs, number of re-renders across inputs in the following interaction journey

 -- Open RPF
 -- Input test in first input
 -- Change type from Fixed to Expression
 -- Switch to YAML view and Visual View again
 
**Reduced ~10% from 6345 to 5712** 

| Before | After |
| -- | -- |
|![image](https://github.com/harness/uicore/assets/100121280/c73de2dd-e17f-4a36-9a15-0aa560f716e9) | ![image](https://github.com/harness/uicore/assets/100121280/4ec40978-36e1-49ff-867a-c1e4f21757f6) |





You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
