### PR TITLE
fix: [CDS-96282]: Disable TextAreaEditable

### DIFF
--- a/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
+++ b/packages/uicore/src/components/ExpressionInput/ExpressionInput.tsx
@@ -343,6 +343,7 @@ export function ExpressionInput(props: ExpressionInputProps): React.ReactElement
         autoFocus={false}
         enforceFocus={false}
         popoverClassName={css.popover}
+        disabled={disabled}
         isOpen={items.length > 0 && !!queryValue}>
         {!newExpressionComponent ? (
           <InputGroup

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.css
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.css
@@ -18,4 +18,9 @@
   border-radius: var(--spacing-2);
   word-break: break-all;
   white-space: pre-wrap;
+
+  &.disabled {
+    background-color: var(--grey-50);
+    cursor: not-allowed;
+  }
 }

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -176,7 +176,7 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
          * plaintext-only is not supported in firefox
          */
         contentEditable={!disabled}
-        onKeyDown={disabled ? () => {} : this.handleKeyDown.bind(this)}
+        onKeyDown={disabled ? undefined : this.handleKeyDown.bind(this)}
         dangerouslySetInnerHTML={{ __html: highlight(deserialize(value)) }}
       />
     )

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -118,7 +118,10 @@ type TextAreaEditableProps = {
 
 export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
   shouldComponentUpdate(nextProps: TextAreaEditableProps) {
-    return nextProps.value !== (this.props.inputRef.current as any)?.textContent
+    return (
+      nextProps.value !== (this.props.inputRef.current as any)?.textContent ||
+      nextProps.disabled !== this.props.disabled
+    )
   }
 
   handleKeyDown(e: any): void {
@@ -159,19 +162,21 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
   }
 
   render() {
-    const { value, inputRef, textAreaClassName, ...rest } = this.props
+    const { value, inputRef, textAreaClassName, disabled, ...rest } = this.props
 
     return (
       <div
         {...rest}
-        className={cx(css.editable, textAreaClassName)}
+        className={cx(css.editable, textAreaClassName, {
+          [css.disabled]: disabled
+        })}
         ref={inputRef}
         /**
          * https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
          * plaintext-only is not supported in firefox
          */
-        contentEditable={true}
-        onKeyDown={this.handleKeyDown.bind(this)}
+        contentEditable={!disabled}
+        onKeyDown={disabled ? () => {} : this.handleKeyDown.bind(this)}
         dangerouslySetInnerHTML={{ __html: highlight(deserialize(value)) }}
       />
     )


### PR DESCRIPTION
**Issue:**

TextAreaEditable component disable property is not working, since disable property is not used to set the content-editable attr

**Fix:**
- set  content-editable attribute to disabled prop
- handle keydown on callback should be undefined when disabled is true


Before: 

https://github.com/harness/uicore/assets/164848360/355285c2-67cb-42e3-b5e2-ac9930d19d44

After:

https://github.com/harness/uicore/assets/164848360/45148192-6a16-42df-9b4b-a826a698762f


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
