### PR TITLE
chore: Version bump for textAreaEditable component disable fix

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.164.2",
+  "version": "3.164.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

Fixed textAreaEditable component disable feature in my previous the https://github.com/harness/uicore/pull/1303, Created a new PR for version bump

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
