### PR TITLE
feat: [PIPE-18571]: expose popover's captureDismiss for KVTagInput component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.164.3",
+  "version": "3.165.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -13,7 +13,7 @@ import {
   MultiSelectOption,
   MultiSelectProps as UiKitMultiSelectProps
 } from '../MultiSelect/MultiSelect'
-import { IconName, TagInput as BPTagInput, Popover, MenuItem, Menu, Position } from '@blueprintjs/core'
+import { IconName, TagInput as BPTagInput, Popover, MenuItem, Menu, Position, IPopoverProps } from '@blueprintjs/core'
 import { Utils } from '../../core/Utils'
 import { Checkbox as UiKitCheckbox, CheckboxProps as UiKitCheckboxProps } from '../Checkbox/Checkbox'
 import { Toggle as UiKitToggle, ToggleProps as UiKitToggleProps } from '../Toggle/Toggle'
@@ -143,6 +143,7 @@ function TagInput<T>(props: TagInputProps<T> & FormikContextProps<any>) {
 export interface KVTagInputProps extends Omit<IFormGroupProps, 'labelFor' | 'items'> {
   name: string
   tagsProps?: Partial<ITagInputProps>
+  popoverProps?: Pick<IPopoverProps, 'captureDismiss'>
   isArray?: boolean
   onChange?: ITagInputProps['onChange']
 }
@@ -150,7 +151,7 @@ export interface KVTagInputProps extends Omit<IFormGroupProps, 'labelFor' | 'ite
 type KVAccumulator = { [key: string]: string }
 
 function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
-  const { formik, name, tagsProps, isArray = false, ...restProps } = props
+  const { formik, name, tagsProps, popoverProps = {}, isArray = false, ...restProps } = props
   const hasError = errorCheck(name, formik)
   const {
     intent = hasError ? Intent.DANGER : Intent.NONE,
@@ -226,7 +227,8 @@ function KVTagInput(props: KVTagInputProps & FormikContextProps<any>) {
         minimal
         disabled={disabled}
         isOpen={showCreatePopover}
-        content={popoverContent}>
+        content={popoverContent}
+        {...popoverProps}>
         <BPTagInput
           values={
             isArray


### PR DESCRIPTION
This will be used to prevent popover close. 

Use case described in: https://harness.atlassian.net/jira/software/c/projects/PIPE/issues/PIPE-18571?filter=18890

Tech details: https://blueprintjs.com/docs/#core/components/popover.closing-on-click




You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
