### PR TITLE
feat: [IDP-2801]: expandAllByDefault prop added to GroupThumbnailSelect

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.0",
+  "version": "3.165.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
+++ b/packages/uicore/src/components/GroupedThumbnailSelect/GroupedThumbnailSelect.tsx
@@ -45,11 +45,12 @@ export function GroupedThumbnailSelect(props: ConnectedGroupedThumbnailSelectPro
     cancelText = 'Close',
     className,
     thumbnailClassName,
+    expandAllByDefault,
     onChange
   } = props
   const value = get(formik.values, name)
 
-  const [showAllOptions, setShowAllOptions] = React.useState(isEmpty(value))
+  const [showAllOptions, setShowAllOptions] = React.useState(isEmpty(value) || expandAllByDefault)
   const [visibleGroups, setVisibleGroups] = React.useState(groups)
 
   const hasError = errorCheck(name, formik)
@@ -57,7 +58,7 @@ export function GroupedThumbnailSelect(props: ConnectedGroupedThumbnailSelectPro
   const helperText = hasError ? <FormError name={name} errorMessage={get(formik?.errors, name)} /> : null
 
   React.useEffect(() => {
-    setShowAllOptions(isEmpty(value))
+    setShowAllOptions(isEmpty(value) || expandAllByDefault)
   }, [value])
 
   React.useEffect(() => {


### PR DESCRIPTION
`GroupedThumbnailSelectProps` extends `ThumbnailSelectProps` which already has `expandAllByDefault` prop, but we were not consuming it.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
