### PR TITLE
fix: [CDS-96839]: fix multitypeinput to have default width

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.2",
+  "version": "3.165.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.tsx
@@ -204,7 +204,7 @@ export function ExpressionAndRuntimeType<T = unknown>(props: ExpressionAndRuntim
       className={cx(mini ? css.mini : css.main, {
         [css.disabled]: type === MultiTypeInputType.RUNTIME || disabled
       })}
-      width={width}
+      width={width || '100%'}
       {...layoutProps}>
       {type === MultiTypeInputType.FIXED && (
         <FixedTypeComponent


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

Added `width: 100%` to multi type input as default so that it occupies the space within the container and not exceed the container by default

Before

<img width="624" alt="image" src="https://github.com/harness/uicore/assets/62999423/798caede-5e89-4a94-9364-99e175b2394a">

After

<img width="624" alt="image" src="https://github.com/harness/uicore/assets/62999423/e81bc183-6192-4149-98e7-bff13b551bf0">


- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
