### PR TITLE
chore: [PIPE-18794]: optimise the ExpressionInput component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.2",
+  "version": "3.165.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
+++ b/packages/uicore/src/components/TextAreaEditable/TextAreaEditable.tsx
@@ -126,24 +126,22 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
 
   handleKeyDown(e: any): void {
     const { textContent } = e.target
+    const { inputRef, onInput, keyDown } = this.props
 
-    if (e.key === '>' && this.props.inputRef.current) {
+    if (e.key === '>' && inputRef.current) {
       e.preventDefault()
       const index = getCaretIndex(e.target)
 
       const newStr =
         (textContent.slice(0, index) as string) + (e.key as string) + (textContent.slice(index).trimEnd() as string)
 
-      this.props.inputRef.current.innerHTML = highlight(sanitizeHTMLTextObject(deserialize(newStr)))
+      inputRef.current.innerHTML = highlight(sanitizeHTMLTextObject(deserialize(newStr)))
 
-      const childNodesTextLength = createChildNodeLengthSumArray(this.props.inputRef.current.childNodes)
+      const childNodesTextLength = createChildNodeLengthSumArray(inputRef.current.childNodes)
 
-      const childIndex = childNodesTextLength.findIndex(i => {
-        return i >= index
-      })
-
-      const child = this.props.inputRef.current.childNodes[childIndex]
-      const prevChild = this.props.inputRef.current.childNodes[childIndex - 1]
+      const childIndex = childNodesTextLength.findIndex(i => i >= index)
+      const child = inputRef.current.childNodes[childIndex]
+      const prevChild = inputRef.current.childNodes[childIndex - 1]
       let offset = 0
       if (prevChild) {
         offset = index - childNodesTextLength[childIndex - 1] + 1
@@ -151,14 +149,14 @@ export class TextAreaEditable extends React.Component<TextAreaEditableProps> {
         offset = index + 1
       }
 
-      this.props.onInput(e)
+      onInput(e)
       /**
        * node.nodeName returns #text for an exclusive Text node
        *  MDN Reference :- https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
        */
       setCaret(child, offset, child.nodeName.toLowerCase() !== '#text')
     }
-    this.props.keyDown(e)
+    keyDown(e)
   }
 
   render() {


### PR DESCRIPTION
Changes and their impact:
  1. **Moving JSX of Popover Second Child to JSX Block:** 
    Earlier the JSX for the dropdown was being created and rendered every time the renderer function was called, moving this into a separate JSX block (<ExpressionDropdown />) will now render when needed ( popover opened) to avoid creation and rendering of the dropdown when the popover is closed
   2.  **Using useMemo for filteredItems:**
   For large `items` array, the react state is recalculated every time the queryValue or items prop is changed, moving them to useMemo ensures that the filtering operation is only performed when necessary.
   
   
![image](https://github.com/harness/uicore/assets/100121280/0e86fb13-9895-49cd-b59b-51dba653522c)

 


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
