### PR TITLE
fix: [CDS-96098]: set active panels false when controlled active id is undefined

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.3",
+  "version": "3.165.4",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -119,6 +119,8 @@ export function AccordionWithoutRef(
   React.useEffect(() => {
     if (controlledActiveId) {
       setActivePanels({ [controlledActiveId]: true })
+    } else {
+      setActivePanels({})
     }
   }, [controlledActiveId])
 


### PR DESCRIPTION
Set all panels in accordion to false when any falsy values is passed in controlled active id

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
