### PR TITLE
feat: [PIPE-18812}]: Add support for passing content to ListHeader

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.3",
+  "version": "3.165.4",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ListHeader/ListHeader.css
+++ b/packages/uicore/src/components/ListHeader/ListHeader.css
@@ -8,3 +8,7 @@
 .listHeader {
   margin: var(--spacing-medium) var(--spacing-xxlarge) !important;
 }
+
+.listHeaderStory {
+  width: 100% !important;
+}

--- a/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
+++ b/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import type { Meta, Story } from '@storybook/react'
+import { Title, Subtitle, ArgsTable, Stories, PRIMARY_STORY, Primary } from '@storybook/addon-docs/blocks'
+import {
+  Layout,
+  ListHeader,
+  sortByName,
+  sortByEmail,
+  sortByCreated,
+  sortByStatus,
+  sortByVersion,
+  SortMethod,
+  Select
+} from '../..'
+import { ListHeaderProps } from './ListHeader'
+import { IconName } from '@blueprintjs/core'
+import css from './ListHeader.css'
+import cx from 'classnames'
+import { noop } from 'lodash-es'
+
+export default {
+  title: 'Components / ListHeader',
+
+  component: ListHeader,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      source: {
+        type: 'code'
+      },
+
+      page: function PageDescription() {
+        return (
+          <>
+            <Title>ListHeader</Title>
+            <Subtitle>
+              <code>{`import {ListHeader} from '@harness/uicore'`}</code>
+            </Subtitle>
+            <Primary />
+            <ArgsTable story={PRIMARY_STORY} />
+
+            <Stories />
+          </>
+        )
+      }
+    }
+  },
+  decorators: [
+    Story => (
+      <Layout.Horizontal spacing="small">
+        <Story />
+      </Layout.Horizontal>
+    )
+  ]
+} as Meta
+
+export const ListHeaderWithoutContent: Story<ListHeaderProps> = () => {
+  return (
+    <ListHeader
+      totalCount={100}
+      sortOptions={[...sortByName, ...sortByEmail, ...sortByCreated, ...sortByStatus, ...sortByVersion]}
+      selectedSortMethod={SortMethod.NameAsc}
+      onSortMethodChange={() => {
+        //
+      }}
+      className={cx(css.listHeaderStory)}
+    />
+  )
+}
+
+export const ListHeaderWithContent: Story<ListHeaderProps> = () => {
+  const items = [
+    {
+      label: 'Service Kubernetes',
+      value: 'service-kubernetes',
+      icon: { name: 'service-kubernetes' as IconName }
+    },
+    {
+      label: 'Service Github',
+      value: 'service-github',
+      icon: { name: 'service-github' as IconName }
+    },
+    { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' as IconName } },
+    { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' as IconName } },
+    { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' as IconName } }
+  ]
+  return (
+    <ListHeader
+      totalCount={100}
+      sortOptions={[...sortByName, ...sortByEmail, ...sortByCreated, ...sortByStatus, ...sortByVersion]}
+      selectedSortMethod={SortMethod.NameAsc}
+      onSortMethodChange={noop}
+      content={
+        <div style={{ width: '240px', marginRight: '12px' }}>
+          <Select items={items} addClearBtn={true} value={items[1]} />
+        </div>
+      }
+      className={cx(css.listHeaderStory)}
+    />
+  )
+}

--- a/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
+++ b/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
@@ -21,7 +21,7 @@ import {
 } from '../..'
 import { ListHeaderProps } from './ListHeader'
 import { IconName } from '@blueprintjs/core'
-import css from './ListHeader.css'
+import css from './ListHeaderStory.css'
 import cx from 'classnames'
 import { noop } from 'lodash-es'
 

--- a/packages/uicore/src/components/ListHeader/ListHeader.tsx
+++ b/packages/uicore/src/components/ListHeader/ListHeader.tsx
@@ -12,20 +12,24 @@ import css from './ListHeader.css'
 import { Layout, Text } from '../../'
 import { SortDropdown, SortDropdownProps } from '../SortDropdown/SortDropdown'
 
-interface ListHeaderProps extends SortDropdownProps {
+export interface ListHeaderProps extends SortDropdownProps {
   totalCount?: number
   className?: string
+  content?: React.ReactNode
 }
 
 export function ListHeader(props: ListHeaderProps): JSX.Element {
-  const { totalCount, className, ...rest } = props
+  const { totalCount, className, content, ...rest } = props
   return (
     <Layout.Horizontal
       flex={{ distribution: 'space-between' }}
       margin={{ bottom: 'small' }}
       className={cx(css.listHeader, className)}>
       <Text font={{ variation: FontVariation.H5 }}>Total: {totalCount}</Text>
-      <SortDropdown {...rest} />
+      <Layout.Horizontal>
+        {content}
+        <SortDropdown {...rest} />
+      </Layout.Horizontal>
     </Layout.Horizontal>
   )
 }

--- a/packages/uicore/src/components/ListHeader/ListHeaderStory.css
+++ b/packages/uicore/src/components/ListHeader/ListHeaderStory.css
@@ -1,10 +1,10 @@
 /*
- * Copyright 2023 Harness Inc. All rights reserved.
+ * Copyright 2024 Harness Inc. All rights reserved.
  * Use of this source code is governed by the PolyForm Shield 1.0.0 license
  * that can be found in the licenses directory at the root of this repository, also available at
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-.listHeader {
-  margin: var(--spacing-medium) var(--spacing-xxlarge) !important;
+.listHeaderStory {
+  width: 100% !important;
 }


### PR DESCRIPTION
This PR adds the support to pass any custom content to ListHeader to be shown with the Sort Filter.

Also added story for ListHeader with and without content.

**- ListHeader with content:**

![Screenshot 2024-05-23 at 12 45 09 PM](https://github.com/harness/uicore/assets/110591046/d275a04e-97bc-40f6-ba09-d0465ad93a44)
<br/>
**- ListHeader without content (Existing behaviour):**
![Screenshot 2024-05-23 at 12 45 00 PM](https://github.com/harness/uicore/assets/110591046/eec118c4-fe69-4dd7-a8af-cec3c57edc11)
<br/>
**- ListHeader in harness core UI with  content:**
![Screenshot 2024-05-23 at 12 44 44 PM](https://github.com/harness/uicore/assets/110591046/15d60770-6be9-4174-a8fb-94f37018cea5)
<br/>
**- ListHeader in harness core UI without content (Existing behaviour):**
![Screenshot 2024-05-23 at 12 44 35 PM](https://github.com/harness/uicore/assets/110591046/f2ab7a2c-a31f-456f-8540-d5b07d672449)


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
