### PR TITLE
fix: [CDS-97305]: fixed confirmation dialog header long text

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.4",
+  "version": "3.165.5",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -85,7 +85,14 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
 
       <Layout.Horizontal className={css.header} padding={{ left: 'xsmall' }}>
         <Icon name={getIconForIntent(intent)} size={32} margin={{ right: 'small' }} intent={intent} />
-        <Text font={{ variation: FontVariation.H4 }}>{titleText}</Text>
+        <Text
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}
+          font={{ variation: FontVariation.H4 }}>
+          {titleText}
+        </Text>
       </Layout.Horizontal>
       <Layout.Vertical
         font={{ variation: FontVariation.BODY }}

--- a/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/ConfirmationDialog.tsx
@@ -40,6 +40,7 @@ export interface ConfirmationDialogProps extends Omit<IDialogProps, 'onClose' | 
   customButtons?: React.ReactNode
   showCloseButton?: boolean
   children?: JSX.Element
+  titleLineClamp?: number
 }
 
 const confirmDialogProps: Partial<IDialogProps> = {
@@ -64,6 +65,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
     showCloseButton = true,
     children,
     className,
+    titleLineClamp,
     ...rest
   } = props
 
@@ -85,12 +87,7 @@ export function ConfirmationDialog(props: ConfirmationDialogProps): React.ReactE
 
       <Layout.Horizontal className={css.header} padding={{ left: 'xsmall' }}>
         <Icon name={getIconForIntent(intent)} size={32} margin={{ right: 'small' }} intent={intent} />
-        <Text
-          style={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis'
-          }}
-          font={{ variation: FontVariation.H4 }}>
+        <Text lineClamp={titleLineClamp} font={{ variation: FontVariation.H4 }}>
           {titleText}
         </Text>
       </Layout.Horizontal>

--- a/packages/uicore/src/components/ConfirmDialog/useConfirmationDialog.tsx
+++ b/packages/uicore/src/components/ConfirmDialog/useConfirmationDialog.tsx
@@ -25,6 +25,7 @@ export interface UseConfirmationDialogProps {
   canEscapeKeyClose?: boolean
   children?: JSX.Element
   className?: string
+  titleLineClamp?: number
 }
 
 export interface UseConfirmationDialogReturn {
@@ -46,7 +47,8 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
     canOutsideClickClose,
     canEscapeKeyClose,
     children,
-    className
+    className,
+    titleLineClamp
   } = props
 
   const [showModal, hideModal] = useModalHook(() => {
@@ -64,7 +66,8 @@ export const useConfirmationDialog = (props: UseConfirmationDialogProps): UseCon
         customButtons={customButtons}
         showCloseButton={showCloseButton}
         canOutsideClickClose={canOutsideClickClose}
-        canEscapeKeyClose={canEscapeKeyClose}>
+        canEscapeKeyClose={canEscapeKeyClose}
+        titleLineClamp={titleLineClamp}>
         {children}
       </ConfirmationDialog>
     )


### PR DESCRIPTION
JIRA:
https://harness.atlassian.net/browse/CDS-97305


Before:
![Screenshot 2024-05-27 at 3 47 35 PM](https://github.com/harness/uicore/assets/164848360/e5a79c68-88c1-413f-902a-62c66f7038ae)

After:
| A    | B |
| -------- | ------- |
| Long Text  ![Screenshot 2024-05-27 at 3 42 22 PM](https://github.com/harness/uicore/assets/164848360/d3eab5e7-c7a5-4c81-839e-59860a458ff0)   |
| Normal Text ![Screenshot 2024-05-27 at 3 59 16 PM](https://github.com/harness/uicore/assets/164848360/c3201436-8e68-4609-bace-3b46c119498c) | Mixed text ![Screenshot 2024-05-27 at 3 43 18 PM](https://github.com/harness/uicore/assets/164848360/c59bb261-57bd-47e9-8d65-6c6e3380a38a)
 


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
