### PR TITLE
feat: [PIPE-18812]: Add support for preDropdownContent & postDropdownContent for ListHeader

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.5",
+  "version": "3.165.6",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
+++ b/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
@@ -25,6 +25,22 @@ import css from './ListHeaderStory.css'
 import cx from 'classnames'
 import { noop } from 'lodash-es'
 
+const selectOptions = [
+  {
+    label: 'Service Kubernetes',
+    value: 'service-kubernetes',
+    icon: { name: 'service-kubernetes' as IconName }
+  },
+  {
+    label: 'Service Github',
+    value: 'service-github',
+    icon: { name: 'service-github' as IconName }
+  },
+  { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' as IconName } },
+  { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' as IconName } },
+  { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' as IconName } }
+]
+
 export default {
   title: 'Components / ListHeader',
 
@@ -75,31 +91,59 @@ export const ListHeaderWithoutContent: Story<ListHeaderProps> = () => {
   )
 }
 
-export const ListHeaderWithContent: Story<ListHeaderProps> = () => {
-  const items = [
-    {
-      label: 'Service Kubernetes',
-      value: 'service-kubernetes',
-      icon: { name: 'service-kubernetes' as IconName }
-    },
-    {
-      label: 'Service Github',
-      value: 'service-github',
-      icon: { name: 'service-github' as IconName }
-    },
-    { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' as IconName } },
-    { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' as IconName } },
-    { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' as IconName } }
-  ]
+export const ListHeaderWithPreDropdownContent: Story<ListHeaderProps> = () => {
   return (
     <ListHeader
       totalCount={100}
       sortOptions={[...sortByName, ...sortByEmail, ...sortByCreated, ...sortByStatus, ...sortByVersion]}
       selectedSortMethod={SortMethod.NameAsc}
       onSortMethodChange={noop}
-      content={
-        <div style={{ width: '240px', marginRight: '12px' }}>
-          <Select items={items} addClearBtn={true} value={items[1]} />
+      preDropdownContent={
+        <div className={cx(css.selectWrapper, css.selectWrapperPre)}>
+          <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+        </div>
+      }
+      className={cx(css.listHeaderStory)}
+    />
+  )
+}
+
+export const ListHeaderWithPostDropdownContent: Story<ListHeaderProps> = () => {
+  return (
+    <ListHeader
+      totalCount={100}
+      sortOptions={[...sortByName, ...sortByEmail, ...sortByCreated, ...sortByStatus, ...sortByVersion]}
+      selectedSortMethod={SortMethod.NameAsc}
+      onSortMethodChange={noop}
+      postDropdownContent={
+        <div>
+          <div className={cx(css.selectWrapper, css.selectWrapperPost)}>
+            <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+          </div>
+        </div>
+      }
+      className={cx(css.listHeaderStory)}
+    />
+  )
+}
+
+export const ListHeaderWithPreAndPostDropdownContent: Story<ListHeaderProps> = () => {
+  return (
+    <ListHeader
+      totalCount={100}
+      sortOptions={[...sortByName, ...sortByEmail, ...sortByCreated, ...sortByStatus, ...sortByVersion]}
+      selectedSortMethod={SortMethod.NameAsc}
+      onSortMethodChange={noop}
+      preDropdownContent={
+        <div className={cx(css.selectWrapper, css.selectWrapperPre)}>
+          <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+        </div>
+      }
+      postDropdownContent={
+        <div>
+          <div className={cx(css.selectWrapper, css.selectWrapperPost)}>
+            <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+          </div>
         </div>
       }
       className={cx(css.listHeaderStory)}

--- a/packages/uicore/src/components/ListHeader/ListHeader.tsx
+++ b/packages/uicore/src/components/ListHeader/ListHeader.tsx
@@ -15,11 +15,12 @@ import { SortDropdown, SortDropdownProps } from '../SortDropdown/SortDropdown'
 export interface ListHeaderProps extends SortDropdownProps {
   totalCount?: number
   className?: string
-  content?: React.ReactNode
+  preDropdownContent?: React.ReactNode
+  postDropdownContent?: React.ReactNode
 }
 
 export function ListHeader(props: ListHeaderProps): JSX.Element {
-  const { totalCount, className, content, ...rest } = props
+  const { totalCount, className, preDropdownContent, postDropdownContent, ...rest } = props
   return (
     <Layout.Horizontal
       flex={{ distribution: 'space-between' }}
@@ -27,8 +28,9 @@ export function ListHeader(props: ListHeaderProps): JSX.Element {
       className={cx(css.listHeader, className)}>
       <Text font={{ variation: FontVariation.H5 }}>Total: {totalCount}</Text>
       <Layout.Horizontal>
-        {content}
+        {preDropdownContent}
         <SortDropdown {...rest} />
+        {postDropdownContent}
       </Layout.Horizontal>
     </Layout.Horizontal>
   )

--- a/packages/uicore/src/components/ListHeader/ListHeaderStory.css
+++ b/packages/uicore/src/components/ListHeader/ListHeaderStory.css
@@ -8,3 +8,15 @@
 .listHeaderStory {
   width: 100% !important;
 }
+
+.selectWrapper {
+  width: 240px;
+
+  &Pre {
+    margin-right: 8px;
+  }
+
+  &Post {
+    margin-left: 8px !important;
+  }
+}


### PR DESCRIPTION
This PR adds the support to pass preDropdownContent &  postDropdownContent to ListHeader to be shown with the Sort Filter.

Enhancement made to changes in https://github.com/harness/uicore/pull/1318

- **With preDropdownContent & postDropdownContent**
![Screenshot 2024-05-31 at 11 36 54 AM](https://github.com/harness/uicore/assets/110591046/b2f54ce4-8bea-4e57-b956-4a01b55c4c20)

- **With postDropdownContent**
![Screenshot 2024-05-31 at 11 37 01 AM](https://github.com/harness/uicore/assets/110591046/50839ff4-c593-4b80-8497-e6b34bcf0f48)

- **With preDropdownContent**
![Screenshot 2024-05-31 at 11 37 13 AM](https://github.com/harness/uicore/assets/110591046/439317ce-9257-4147-af3d-86c8b27f839e)

- **No preDropdownContent & postDropdownContent**
![Screenshot 2024-05-31 at 11 37 20 AM](https://github.com/harness/uicore/assets/110591046/1bed4972-7d1b-42d4-9fa6-92e807ce412b)

- **With postDropdownContent in Hanerss Core UI**
<img width="1498" alt="Screenshot 2024-05-31 at 5 04 37 PM" src="https://github.com/harness/uicore/assets/110591046/015319b9-89da-46cb-83a1-ffdef8af5223">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
