### PR TITLE
feat: [PL-51672]: Passed className from props to BpTabs

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.165.6",
+  "version": "3.165.7",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Tabs/Tabs.tsx
+++ b/packages/uicore/src/components/Tabs/Tabs.tsx
@@ -39,18 +39,22 @@ function tab(props: TabProps) {
 }
 
 function Tabs(props: TabsProps): React.ReactElement {
-  const { renderAllTabPanels, vertical, children, tabList = [], ...rest } = props
+  const { renderAllTabPanels, vertical, children, className, tabList = [], ...rest } = props
   const hasIcons = tabList.findIndex(tabProp => tabProp.iconProps?.name) !== -1
   return (
     <BpTabs
       {...rest}
       vertical={vertical}
       renderActiveTabPanelOnly={!renderAllTabPanels}
-      className={cx(css.main, {
-        [css.vertical]: vertical,
-        [css.horizontal]: !vertical,
-        [css.icons]: hasIcons && !vertical
-      })}>
+      className={cx(
+        css.main,
+        {
+          [css.vertical]: vertical,
+          [css.horizontal]: !vertical,
+          [css.icons]: hasIcons && !vertical
+        },
+        className
+      )}>
       {tabList.map(tabProp => {
         return tab(tabProp)
       })}


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/PL-51672

**Problem:** Tabs component does not honour "className" prop. 

**Solution:** Passed className from props to `<BpTabs ... />`




BEFORE:
<img width="595" alt="image" src="https://github.com/harness/uicore/assets/96057095/a9754543-f54e-4eb5-abc3-d7d4cf5fa556">

<img width="1725" alt="PL-51672_BEFORE" src="https://github.com/harness/uicore/assets/96057095/e1c6cc80-7f75-469f-86dd-4e404b1d4a25">


AFTER:
Random className: `hohoho` is honoured
<img width="1682" alt="PL-51672_AFTER" src="https://github.com/harness/uicore/assets/96057095/d8b9a349-9f4c-47bc-aeb0-5eed2d2949b4">



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
