### PR TITLE
fix: remove @harness/design-system dependancy from all packages

### DIFF
--- a/packages/help-panel/package.json
+++ b/packages/help-panel/package.json
@@ -25,12 +25,11 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "peerDependencies": {
-    "@harness/design-system": "^1.0.0",
+    "@harnessio/design-system": "^1.6.0-beta.2",
     "react": "^17.0.2"
   },
   "devDependencies": {
     "@contentful/rich-text-types": "^15.12.0",
-    "@harness/design-system": "^1.4.0",
     "@harnessio/design-system": "^1.6.0-beta.2",
     "@types/react": "^17.0.3",
     "dts-bundle-generator": "^6.4.0",

--- a/packages/logos/package.json
+++ b/packages/logos/package.json
@@ -24,13 +24,11 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "peerDependencies": {
-    "@harness/design-system": "^1.0.0",
     "@harnessio/design-system": "1.6.0-beta.2",
     "@harnessio/icons": "^2.0.0-beta.2",
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@harness/design-system": "^1.4.0",
     "@harnessio/design-system": "^1.6.0-beta.2",
     "@harnessio/icons": "^2.0.0-beta.2",
     "@svgr/core": "^6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,20 +1301,15 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@harness/design-system@^1.4.0":
-  version "1.6.0"
-  resolved "https://npm.pkg.github.com/download/@harness/design-system/1.6.0/08be4ff6b6e6a42f163f69d6141875d995685a02#08be4ff6b6e6a42f163f69d6141875d995685a02"
-  integrity "sha1-CL5P9rbmpC8WP2nWFBh12ZVoWgI= sha512-Js2mtSIrCrc0Slsc0P4+MGxQwIPqwwC6ynbSeytYaWmUHbvp9oXzuTw9ZN2CYYstaEv+xI6tJDCEJ4vqoM8ubw=="
-
 "@harnessio/design-system@1.6.0-beta.2":
   version "1.6.0-beta.2"
   resolved "https://registry.npmjs.org/@harnessio/design-system/-/design-system-1.6.0-beta.2.tgz#88f09604e43ae0b843f8c243e0d6a79ad68798e9"
   integrity sha512-iDNK/SuPDD8PSVP/CbLeSLAGkheR1/BGamQh9fdQrjlprVLG82YA3dCeWfVecZwsxcN5LKfSSFqJAPmWi8yTuQ==
 
 "@harnessio/design-system@^1.6.0-beta.2":
-  version "1.6.0-beta.1b"
-  resolved "https://registry.npmjs.org/@harnessio/design-system/-/design-system-1.6.0-beta.1b.tgz#f124f93b2232f1790fac82a5e71ab76254724f8d"
-  integrity sha512-GlTaQjWopiuKl+9kRjVSJJHpSHp5tZDMw26Dr5vS8x6Tdibv9+i4McjkXF3ZAMfhmpgnpk8wbyr0KI8TyJ6gGQ==
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@harnessio/design-system/-/design-system-1.6.0.tgz#8d9323d1d5b8881b41069f7a98c700eca78481c9"
+  integrity sha512-MpNxpRBZLw9vMK/kDtFURI3JcN4cxxzj8STevZZoWbPZyEJ9/y/KJYi2GdERZ0z4Is/ccPv3ZcKDo3OK08OFVA==
 
 "@hutson/parse-repository-url@^3.0.0":
   version "3.0.2"


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
