### PR TITLE
fix: [PIPE-20089]: Bug fix to honor "onFocus" from props

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.167.0",
+  "version": "3.167.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -1156,7 +1156,12 @@ const FormMultiTypeInput = (props: FormMultiTypeInputProps & FormikContextProps<
           loadingItems: loading
         }}
         onChange={onChangeCallback}
-        onFocus={fetchItems}
+        onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+          multiTypeInputProps?.onFocus?.(event)
+          if (isAsyncSelect) {
+            fetchItems()
+          }
+        }}
       />
     </FormGroup>
   )


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

As a follow up to PR https://github.com/harness/uicore/pull/1333, this change is to ensure backward compatibility, since an existing `onFocus` prop passed, if any, should be honored and not swallowed instead.

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
