### PR TITLE
fix: [PL-55491]: use checked instead of defaultChecked in radio input

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.167.1",
+  "version": "3.167.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/RadioButton/RadioButton.tsx
+++ b/packages/uicore/src/components/RadioButton/RadioButton.tsx
@@ -48,7 +48,7 @@ export function RadioButton({
         type="radio"
         name={name}
         value={value}
-        defaultChecked={checked}
+        checked={checked}
         disabled={disabled}
         className={css.input}
         onChange={onChange}


### PR DESCRIPTION
The base component (`<input type='radio' />`) was using `defaultChecked` prop to toggle it's state which prevents it from being changed by external sources. Using `checked` prop enables it to be changed by external sources while maintaining all the previous functionality


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
