### PR TITLE
fix: [IRO-283]: fixed issues with cyclic dependencies

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/uicore",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/CollapsableSelect/CollapsableSelect.test.tsx
+++ b/packages/uicore/src/components/CollapsableSelect/CollapsableSelect.test.tsx
@@ -9,8 +9,8 @@ import React from 'react'
 import { render, fireEvent, act } from '@testing-library/react'
 import { CollapsableSelectType, FormikCollapsableSelect } from './CollapsableSelect'
 import { Form, Formik } from 'formik'
-import { Layout } from 'index'
 import { noop } from 'lodash'
+import { Layout } from '../../layouts/Layout'
 
 const items = [
   {

--- a/packages/uicore/src/components/DropDown/DropDown.stories.tsx
+++ b/packages/uicore/src/components/DropDown/DropDown.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, Story } from '@storybook/react'
 import { Title, Subtitle, ArgsTable, Stories, PRIMARY_STORY, Primary } from '@storybook/addon-docs/blocks'
 import { DropDown, DropDownProps } from './DropDown'
 import { Layout } from '../../layouts/Layout'
-import { SelectOption } from 'index'
+import { SelectOption } from '../../components/Select/Select'
 
 const staticItems = [
   { label: 'Aborted', value: 'aborted' },

--- a/packages/uicore/src/components/Page/__tests__/PageError.test.tsx
+++ b/packages/uicore/src/components/Page/__tests__/PageError.test.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react'
-import { Layout, Text } from 'index'
 import { render } from '@testing-library/react'
+import { Layout } from '../../../layouts/Layout'
+import { Text } from '../../../components/Text/Text'
 import { PageError } from '../PageError'
 
 describe('PageError test', () => {

--- a/packages/uicore/src/components/SelectWithSubmenu/SelectWithSubmenuV2.tsx
+++ b/packages/uicore/src/components/SelectWithSubmenu/SelectWithSubmenuV2.tsx
@@ -15,7 +15,7 @@ import { Text } from '../Text/Text'
 import css from './SelectWithSubmenuV2.css'
 import selectCss from '../Select/Select.css'
 import { SelectProps, SelectOption, Select } from '../../components/Select/Select'
-import { MultiTypeInputType } from 'index'
+import { MultiTypeInputType } from '../../components/MultiTypeInput/MultiTypeInputUtils'
 
 export interface SubmenuSelectOption extends SelectOption {
   submenuItems: SelectOption[]

--- a/packages/uicore/src/frameworks/Tooltip/TooltipContext.tsx
+++ b/packages/uicore/src/frameworks/Tooltip/TooltipContext.tsx
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { UseTooltipsReturn } from 'index'
 import React from 'react'
-import { TooltipContextProviderProps, TooltipContextValue, TooltipDictionaryValue } from './types'
+import { TooltipContextProviderProps, TooltipContextValue, TooltipDictionaryValue, UseTooltipsReturn } from './types'
 
 export const TooltipContext = React.createContext<TooltipContextValue>({ tooltipDictionary: {} })
 


### PR DESCRIPTION
While using `@harnessio/uicore@4.1.2` in an open source project, we noticed this error popping up. 


![image](https://github.com/user-attachments/assets/a3ed5054-59f5-45a9-9c48-eb253910e4b7)

Upon inspection if uicore, we noticed that some types were imported from the `index` file which was causing the same.

After fixing this in uicore repo and testing with yalc we can confirm that this fixes our issues. 

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
