### PR TITLE
feat: [PIPE-21132]: added support for chevron positioning in accordion

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.172.0",
+  "version": "3.172.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Accordion/Accordion.css
+++ b/packages/uicore/src/components/Accordion/Accordion.css
@@ -37,6 +37,11 @@
       color: var(--black);
       padding-right: var(--spacing-4) !important;
     }
+
+    .iconPositionedLeft {
+      padding-right: 0 !important;
+      padding-left: var(--spacing-4);
+    }
   }
 
   .chevron {

--- a/packages/uicore/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.stories.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import type { Meta, Story } from '@storybook/react'
 import { Button, IButtonProps } from '@blueprintjs/core'
 
-import { Accordion, AccordionProps } from './Accordion'
+import { Accordion, AccordionProps, ChevronPosition } from './Accordion'
 import { NestedAccordionProvider, NestedAccordionPanel, useNestedAccordion } from './NestedAccordion'
 
 const text = `Lorem ipsum dolor sit amet consectetur adipisicing elit. Quasi temporibus error, id recusandae doloribus earum inventore, soluta fugit quidem nulla labore optio incidunt quis facilis. Rem illum unde tempore tempora.`
@@ -32,6 +32,14 @@ Basic.args = {
   onChange(tabs) {
     // eslint-disable-next-line no-console
     console.log('changed tabs', tabs)
+  },
+  chevronPosition: ChevronPosition.RIGHT
+}
+
+Basic.argTypes = {
+  chevronPosition: {
+    options: [ChevronPosition.RIGHT, ChevronPosition.LEFT],
+    control: { type: 'select' }
   }
 }
 

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -13,6 +13,11 @@ import css from './Accordion.css'
 
 const noop = () => void 0
 
+export enum ChevronPosition {
+  LEFT = 'left',
+  RIGHT = 'right'
+}
+
 export interface AccordionPanelProps {
   id: string
   details: React.ReactNode
@@ -21,6 +26,7 @@ export interface AccordionPanelProps {
   disabled?: boolean
   className?: string
   shouldRender?: boolean | (() => boolean)
+  chevronPosition?: ChevronPosition
 }
 
 export interface AccordionPanelInternalProps extends Omit<AccordionProps, 'children' | 'activeId' | 'className'> {
@@ -48,7 +54,8 @@ function AccordionPanel(
     detailsClassName,
     chevronClassName,
     className,
-    shouldRender
+    shouldRender,
+    chevronPosition = ChevronPosition.RIGHT
   } = props
 
   if (typeof shouldRender === 'boolean' && !shouldRender) {
@@ -68,8 +75,15 @@ function AccordionPanel(
       data-open={isOpen}
       id={addDomId ? `${id}-panel` : undefined}>
       <div data-testid={`${id}-summary`} onClick={togglePanel} className={cx(css.summary, summaryClassName)}>
-        <div className={cx({ [css.label]: typeof summary === 'string' })}>{summary}</div>
-        <div className={cx(css.chevron, chevronClassName)} />
+        {chevronPosition === ChevronPosition.LEFT && <div className={cx(css.chevron, chevronClassName)} />}
+        <div
+          className={cx({
+            [css.label]: typeof summary === 'string',
+            [css.iconPositionedLeft]: typeof summary === 'string' && chevronPosition === ChevronPosition.LEFT
+          })}>
+          {summary}
+        </div>
+        {chevronPosition === ChevronPosition.RIGHT && <div className={cx(css.chevron, chevronClassName)} />}
       </div>
       <Collapse {...collapseProps} className={cx(css.collapse, collapseProps?.className)} isOpen={isOpen}>
         <div data-testid={`${id}-details`} className={cx(css.details, detailsClassName)}>
@@ -93,6 +107,7 @@ export interface AccordionProps {
   onChange?(tabs: string | string[]): void
   /** Controlled accordion active ID which drives accordion state from onChange over internal toggle state  */
   controlledActiveId?: string
+  chevronPosition?: ChevronPosition
 }
 
 export interface AccordionHandle {


### PR DESCRIPTION


Adding support for accordion icon positioning

https://github.com/user-attachments/assets/e4153630-d38a-4908-bfbd-e3b653b798ee

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
