### PR TITLE
feat: [DBOPS-138]: Add getRowClassName to TableV3

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.172.1",
+  "version": "3.173.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/TableV3/TableV3.tsx
+++ b/packages/uicore/src/components/TableV3/TableV3.tsx
@@ -15,7 +15,8 @@ import {
   Column,
   SortingState,
   getSortedRowModel,
-  ColumnPinningState
+  ColumnPinningState,
+  Row
 } from '@tanstack/react-table'
 import cx from 'classnames'
 import Pagination, { PaginationProps } from '../Pagination/Pagination'
@@ -47,6 +48,7 @@ export interface TableV3Props<T> {
   useDynamicTableSize?: boolean
   className?: string
   pagination?: PaginationProps
+  getRowClassName?: (row: Row<T>) => string | undefined
 }
 
 export function TableV3<T>(props: TableV3Props<T>) {
@@ -56,7 +58,8 @@ export function TableV3<T>(props: TableV3Props<T>) {
     columnPinning = { left: [], right: [] },
     useDynamicTableSize,
     className,
-    pagination
+    pagination,
+    getRowClassName
   } = props
 
   const [sorting, setSorting] = React.useState<SortingState>([])
@@ -101,7 +104,7 @@ export function TableV3<T>(props: TableV3Props<T>) {
         </thead>
         <tbody>
           {table.getRowModel().rows.map(row => (
-            <tr key={row.id}>
+            <tr key={row.id} className={getRowClassName?.(row)}>
               {row.getVisibleCells().map(cell => {
                 const { column } = cell
                 return (


### PR DESCRIPTION
Change:
Adding `className` dynamically to every row in the table.

Use case:
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/52c37cf2-a72d-4c25-8066-43c50c2377c5">


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
