### PR TITLE
feat: [STO-7995] MultiTypeInput dark mode fix

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.173.1",
+  "version": "3.173.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.css
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.css
@@ -139,9 +139,8 @@
   &::before {
     content: '';
     height: 22px;
-    width: var(--spacing-3);
+    width: 6px;
     transform: translateX(-18px);
-    background: var(--white);
     border-radius: var(--spacing-2);
     border-right: 1px solid var(--grey-100);
     position: absolute;
@@ -199,9 +198,8 @@
     content: '';
     height: 30px;
     left: var(--spacing-4);
-    width: var(--spacing-3);
+    width: 6px;
     transform: translateX(-18px);
-    background: var(--white);
     border-radius: var(--spacing-2);
     border-right: 1px solid var(--bp3-intent-color, var(--grey-200));
     position: absolute;


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

Bug:
<img width="1293" alt="Screenshot 2024-09-04 at 11 02 35 AM" src="https://github.com/user-attachments/assets/e7932074-82be-4e9e-a45f-d4491b602668">


Fix:
<img width="1293" alt="Screenshot 2024-09-04 at 11 23 16 AM" src="https://github.com/user-attachments/assets/4251e8a8-c99b-4507-9563-1a9f7caafa26">

Fix (light mode)
<img width="1293" alt="Screenshot 2024-09-04 at 11 23 26 AM" src="https://github.com/user-attachments/assets/64cfaa62-9857-4f1f-9323-57a3f463f9d9">



- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
