### PR TITLE
feat: [PIPE-21132]: added support for allowOtherChildElem and multiple IDs in controlledActiveId

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.174.0",
+  "version": "3.175.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.stories.tsx
@@ -34,8 +34,7 @@ Basic.args = {
     console.log('changed tabs', tabs)
   },
   chevronPosition: ChevronPosition.RIGHT,
-  allowMultiOpen: true,
-  openAllByDefault: true
+  allowMultiOpen: true
 }
 
 Basic.argTypes = {

--- a/packages/uicore/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.stories.tsx
@@ -33,7 +33,9 @@ Basic.args = {
     // eslint-disable-next-line no-console
     console.log('changed tabs', tabs)
   },
-  chevronPosition: ChevronPosition.RIGHT
+  chevronPosition: ChevronPosition.RIGHT,
+  allowMultiOpen: true,
+  openAllByDefault: true
 }
 
 Basic.argTypes = {

--- a/packages/uicore/src/components/Accordion/Accordion.tsx
+++ b/packages/uicore/src/components/Accordion/Accordion.tsx
@@ -106,10 +106,9 @@ export interface AccordionProps {
   allowMultiOpen?: boolean
   onChange?(tabs: string | string[]): void
   /** Controlled accordion active ID which drives accordion state from onChange over internal toggle state  */
-  controlledActiveId?: string
+  controlledActiveId?: string | string[]
   chevronPosition?: ChevronPosition
   allowOtherChildElem?: boolean
-  openAllByDefault?: boolean
 }
 
 export interface AccordionHandle {
@@ -130,33 +129,22 @@ export function AccordionWithoutRef(
     onChange,
     controlledActiveId,
     allowOtherChildElem,
-    openAllByDefault,
     ...rest
   } = props
 
   // Use the controlledActiveId prop to manage the active panels
   const [activePanels, setActivePanels] = React.useState<Record<string, boolean>>(() => {
     if (controlledActiveId) {
-      return { [controlledActiveId]: true }
+      return getControlledActiveIds(controlledActiveId)
     }
 
-    return activeId && typeof activeId === 'string'
-      ? { [activeId]: true }
-      : React.Children.toArray(children)
-          .filter(child => (child as any).type === Accordion.Panel)
-          .reduce(
-            (acc: any, child: any) => ({
-              ...acc,
-              [child.props.id]: openAllByDefault ? true : false
-            }),
-            {} as Object
-          )
+    return activeId && typeof activeId === 'string' ? { [activeId]: true } : {}
   })
 
   // Handle changes in controlledActiveId prop
   React.useEffect(() => {
     if (controlledActiveId) {
-      setActivePanels({ [controlledActiveId]: true })
+      setActivePanels(getControlledActiveIds(controlledActiveId))
     }
   }, [controlledActiveId])
 
@@ -169,6 +157,12 @@ export function AccordionWithoutRef(
         onChange?.(id)
       }
     }
+  }
+
+  function getControlledActiveIds(controlledActiveId: string | string[]) {
+    return Array.isArray(controlledActiveId)
+      ? controlledActiveId.reduce((acc, id) => ({ ...acc, [id]: true }), {})
+      : { [controlledActiveId]: true }
   }
 
   function resolveTabs(tab: string | string[]): string[] {

--- a/packages/uicore/src/index.ts
+++ b/packages/uicore/src/index.ts
@@ -7,7 +7,7 @@
 
 import './styles/styles.css'
 export { Config } from './core/Config'
-export { Accordion, AccordionProps, AccordionHandle } from './components/Accordion/Accordion'
+export { Accordion, AccordionProps, AccordionHandle, ChevronPosition } from './components/Accordion/Accordion'
 export {
   NestedAccordionProvider,
   NestedAccordionPanel,


### PR DESCRIPTION
Adding 2 additional props in the accordion component

- allowOtherChildElem - To render other elements other than accordion children
- controlledActiveId - Now we can passed multiple active ID width controlled component. ease to use with combination of allowMultiOpen prop


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
