### PR TITLE
fix: [CDS-99267]: Update toggle pill color for dark and light mode

### DIFF
--- a/packages/uicore/src/components/Toggle/Toggle.css
+++ b/packages/uicore/src/components/Toggle/Toggle.css
@@ -6,11 +6,11 @@
  */
 
 .toggle {
-  --toggle-background-color: var(--white);
+  --toggle-background-color: var(--grey-100);
   --toggle-border-color: #c7c9d9; /* grey-200 too light and grey-250/300 too dark */
   --toggle-pill-size: var(--spacing-4);
-  --toggle-pill-color: var(--toggle-border-color); /* Needs to be consistent in light and dark mode */
-  --toggle-pill-shadow: 0 1px 2px var(--grey-200), 0 2px 4px var(--grey-200);
+  --toggle-pill-color: #ffffff; /* Needs to be consistent in light and dark mode */
+  --toggle-pill-shadow: 0 1px 2px rgba(40, 41, 61, 0.2), 0 2px 4px rgba(96, 97, 112, 0.2);
 
   line-height: 1rem;
   font-size: var(--font-size-small);
@@ -47,9 +47,6 @@
   justify-content: flex-end;
   --toggle-background-color: var(--primary-7);
   --toggle-border-color: var(--primary-7);
-}
-.input:checked ~ .toggleIcon::before {
-  --toggle-pill-color: var(--white);
 }
 
 .input:disabled ~ .toggleIcon {

--- a/packages/uicore/src/components/Toggle/Toggle.css
+++ b/packages/uicore/src/components/Toggle/Toggle.css
@@ -9,8 +9,8 @@
   --toggle-background-color: var(--white);
   --toggle-border-color: #c7c9d9; /* grey-200 too light and grey-250/300 too dark */
   --toggle-pill-size: var(--spacing-4);
-  --toggle-pill-color: var(--white);
-  --toggle-pill-shadow: 0 1px 2px rgba(40, 41, 61, 0.2), 0 2px 4px rgba(96, 97, 112, 0.2);
+  --toggle-pill-color: #c7c9d9; /* Needs to be consistent in light and dark mode */
+  --toggle-pill-shadow: 0 1px 2px var(--grey-200), 0 2px 4px var(--grey-200);
 
   line-height: 1rem;
   font-size: var(--font-size-small);
@@ -47,6 +47,9 @@
   justify-content: flex-end;
   --toggle-background-color: var(--primary-7);
   --toggle-border-color: var(--primary-7);
+}
+.input:checked ~ .toggleIcon::before {
+  --toggle-pill-color: var(--white);
 }
 
 .input:disabled ~ .toggleIcon {

--- a/packages/uicore/src/components/Toggle/Toggle.css
+++ b/packages/uicore/src/components/Toggle/Toggle.css
@@ -9,7 +9,7 @@
   --toggle-background-color: var(--white);
   --toggle-border-color: #c7c9d9; /* grey-200 too light and grey-250/300 too dark */
   --toggle-pill-size: var(--spacing-4);
-  --toggle-pill-color: #c7c9d9; /* Needs to be consistent in light and dark mode */
+  --toggle-pill-color: var(--toggle-border-color); /* Needs to be consistent in light and dark mode */
   --toggle-pill-shadow: 0 1px 2px var(--grey-200), 0 2px 4px var(--grey-200);
 
   line-height: 1rem;


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`

<img width="487" alt="Screenshot 2024-10-01 at 12 41 57 PM" src="https://github.com/user-attachments/assets/900016d4-5aa2-44d9-94cf-1be86b02d11c">

<img width="487" alt="Screenshot 2024-10-01 at 12 42 21 PM" src="https://github.com/user-attachments/assets/4f79ff9c-bc43-47d3-ac51-874ad87bd592">

<img width="487" alt="Screenshot 2024-10-01 at 12 42 03 PM" src="https://github.com/user-attachments/assets/3946e378-9acf-4819-aa1c-4f7794ed8061">

<img width="487" alt="Screenshot 2024-10-01 at 12 42 17 PM" src="https://github.com/user-attachments/assets/fda8bbe7-0ef7-4dff-9477-c424695882ba">

