### PR TITLE
fix: [CDS-101106]: fix textual component links

### DIFF
--- a/packages/uicore/src/_stories/typography.stories.mdx
+++ b/packages/uicore/src/_stories/typography.stories.mdx
@@ -28,7 +28,7 @@ These CSS variables are used internally inside UICore. When you build a componen
 
 ## Textual Components
 
-- [Heading](/heading)
-- [Text](/text)
-- [Link](/link)
-- [Code](/code) - TBD
+- [Heading](/story/components-heading--weights)
+- [Text](/story/components-text--basic)
+- [Link](/story/components-link--basic)
+- Code - TBD


### PR DESCRIPTION
The links in typography stories page did not work. Fixed by adding correct links

https://github.com/user-attachments/assets/51ad5a03-2013-48fc-a289-cd755e630d31



You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
