### PR TITLE
fix: [PIPE-21956]: Make learn more popover border radius consistemt

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.175.0",
+  "version": "3.175.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.css
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.css
@@ -364,12 +364,13 @@
 
 .learnMorePopover {
   width: 415px;
-  border-radius: 4px 0 4px 4px;
+  border-radius: 4px;
   box-shadow: var(--elevation-4) !important;
   background-color: var(--white);
 
   .learnMore {
     width: 100%;
+    border-radius: 4px 4px 0 0;
   }
 
   .body {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks
**Before:**
![Screenshot 2024-09-20 at 9 28 48 AM](https://github.com/user-attachments/assets/ccf2504c-0ca4-4518-822f-436586136f9c)


**After:**
![Screenshot 2024-09-20 at 9 27 58 AM](https://github.com/user-attachments/assets/f3b20797-b4cb-4a99-b6fa-20a0fb293717)

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
