### PR TITLE
fix: [CDS-101412]: remove search value after popover close

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.175.1",
+  "version": "3.176.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.css
+++ b/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.css
@@ -126,9 +126,13 @@
               background: var(--primary-7);
               color: var(--white) !important;
             }
-            &:hover:local:not(.active, .disabled) {
+            &:hover:local:not(.active, .disabled, .noResultsFound) {
               background: var(--grey-100);
               color: var(--black) !important;
+            }
+            &.noResultsFound {
+              cursor: default;
+              color: var(--grey-400);
             }
           }
         }

--- a/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.tsx
+++ b/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.tsx
@@ -34,7 +34,7 @@ import { PopoverProps } from '../../../Popover/Popover'
 type Props = IQueryListProps<SelectOption>
 
 export function NoMatch(): React.ReactElement {
-  return <li className={cx(css.menuItem)}>No matching results found</li>
+  return <li className={cx(css.menuItem, css.noResultsFound)}>No matching results found</li>
 }
 
 export interface FilterSelectDropDownProps
@@ -143,6 +143,7 @@ export function FiltersSelectDropDown(props: FilterSelectDropDownProps): React.R
   function handleItemSelect(item: SelectOption): void {
     setSelectedItem(item)
     onChange?.(item)
+    setQuery('')
   }
 
   function handleClearSelection() {
@@ -187,6 +188,8 @@ export function FiltersSelectDropDown(props: FilterSelectDropDownProps): React.R
         onClose={() => {
           setIsOpen(false)
           onPopoverClose?.(selectedItem)
+          expandingSearchInputProps?.onChange?.('')
+          setQuery('')
         }}
         className={cx(css.main, className)}
         popoverClassName={cx(css.popover, popoverClassName)}

--- a/packages/uicore/src/components/Filters/components/FiltersMultiSelectDropDown/FiltersMultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/Filters/components/FiltersMultiSelectDropDown/FiltersMultiSelectDropDown.tsx
@@ -218,7 +218,6 @@ export function FiltersMultiSelectDropDown(props: FilterMultiSelectDropDownProps
                   usePortal={true}
                   interactionKind={PopoverInteractionKind.HOVER}
                   className={Classes.DARK}
-                  onClose={() => setQuery('')}
                   content={
                     selectedItems.length > 0 ? (
                       <Container className={css.selectedItemsPopover}>

--- a/packages/uicore/src/components/Filters/components/FiltersMultiSelectDropDown/FiltersMultiSelectDropDown.tsx
+++ b/packages/uicore/src/components/Filters/components/FiltersMultiSelectDropDown/FiltersMultiSelectDropDown.tsx
@@ -186,7 +186,11 @@ export function FiltersMultiSelectDropDown(props: FilterMultiSelectDropDownProps
         }}
         autoFocus={false}
         enforceFocus={false}
-        onClose={() => onPopoverClose?.(selectedItems)}
+        onClose={() => {
+          expandingSearchInputProps?.onChange?.('')
+          setQuery('')
+          onPopoverClose?.(selectedItems)
+        }}
         className={cx(css.main, { [css.disabled]: !!disabled }, className)}
         popoverClassName={cx(css.popover, popoverClassName)}
         isOpen={isOpen}>
@@ -214,6 +218,7 @@ export function FiltersMultiSelectDropDown(props: FilterMultiSelectDropDownProps
                   usePortal={true}
                   interactionKind={PopoverInteractionKind.HOVER}
                   className={Classes.DARK}
+                  onClose={() => setQuery('')}
                   content={
                     selectedItems.length > 0 ? (
                       <Container className={css.selectedItemsPopover}>


### PR DESCRIPTION
When the dropdown is closed, we should not retain the search value

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
