### PR TITLE
feat: [CDS-101545]: add support for sections in dropdown

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.176.0",
+  "version": "3.177.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.css
+++ b/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.css
@@ -164,3 +164,13 @@
 .disabled {
   background-color: var(--grey-200) !important;
 }
+
+.sectionTitle {
+  border-top: none !important;
+  margin-top: 0px !important;
+  h6 {
+    color: var(--grey-500) !important;
+    font-size: 11px;
+    font-weight: 400;
+  }
+}

--- a/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.stories.tsx
+++ b/packages/uicore/src/components/Filters/components/FilterSingleSelectDropDown/FiltersSelectDropDown.stories.tsx
@@ -56,12 +56,17 @@ export const Basic: Story<FilterSelectDropDownProps> = args => {
   const argsCopy = omit(args, ['items', 'onChange', 'value'])
 
   const [value, setValue] = React.useState<SelectOption>({ label: 'Bulbasaur', value: 1 })
+  const sections = {
+    General: ['001', 'pipelineTags', 'myDeployments', 'timeRange', 'pipelineName'],
+    Advance: ['hello']
+  }
 
   return (
     <Layout.Horizontal flex>
       <FiltersSelectDropDown
         items={items}
         value={value}
+        sections={sections}
         allowSearch
         showDropDownIcon
         onChange={items => {


### PR DESCRIPTION

<img width="263" alt="image" src="https://github.com/user-attachments/assets/c6a44d36-d5b3-4086-bb33-b5467aa66341">

Added section and section titles support in single select dropdown

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
