### PR TITLE
feat: [UI-1698]: Export `useFormikContext`

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.178.0",
+  "version": "3.179.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { ReactNode, useCallback, useMemo, useState, useRef, useEffect } from 'react'
-import { connect, Form as FrmForm, Formik as FrmFormik, FormikConfig, FormikHelpers } from 'formik'
+import { connect, Form as FrmForm, Formik as FrmFormik, FormikConfig, FormikHelpers, useFormikContext } from 'formik'
 import {
   LoadingSelectOption,
   SelectOption,
@@ -1869,3 +1869,6 @@ export const FormInput = {
 }
 
 export const FormikForm = connect(Form)
+
+// allow access to the form context without prop drilling
+export { useFormikContext }

--- a/packages/uicore/src/index.ts
+++ b/packages/uicore/src/index.ts
@@ -124,7 +124,7 @@ export { handleZeroOrInfinityTrend, renderTrend } from './components/StackedSumm
 export { timeSeriesChartDefaultConfig } from './components/TimeSeriesChart/TimeSeriesChart'
 export { columnChartDefaultConfig } from './components/ColumnChart/ColumnChart'
 export { Table, TableProps } from './components/Table/Table'
-export { FormikForm, Formik, FormInput } from './components/FormikForm/FormikForm'
+export { FormikForm, Formik, FormInput, useFormikContext } from './components/FormikForm/FormikForm'
 export { errorCheck, getFormFieldLabel } from './components/FormikForm/utils'
 export { StepsProgress } from './components/StepsProgress/StepsProgress'
 export { OverlaySpinner, OverlaySpinnerProps } from './components/OverlaySpinner/OverlaySpinner'


### PR DESCRIPTION
This PR exports the `useFormikContext` hook from the `Formik` package used in UICore.


You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
