### PR TITLE
fix: [CDS-98484]: add checked property to radio input along with defaultChecked

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.178.0",
+  "version": "3.179.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/RadioButton/RadioButton.tsx
+++ b/packages/uicore/src/components/RadioButton/RadioButton.tsx
@@ -20,6 +20,7 @@ export interface RadioButtonProps extends StyledProps {
   disabled?: boolean
   tooltipId?: string
   asPill?: boolean
+  defaultChecked?: boolean
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
@@ -28,6 +29,7 @@ export function RadioButton({
   value,
   name = '',
   className = '',
+  defaultChecked = false,
   checked = false,
   disabled = false,
   tooltipId,
@@ -48,7 +50,8 @@ export function RadioButton({
         type="radio"
         name={name}
         value={value}
-        defaultChecked={checked}
+        defaultChecked={defaultChecked}
+        checked={checked}
         disabled={disabled}
         className={css.input}
         onChange={onChange}

--- a/packages/uicore/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/uicore/src/components/RadioButton/RadioButtonGroup.tsx
@@ -21,6 +21,7 @@ export interface RadioButtonGroupProps extends StyledProps {
   onChange: (e: FormEvent<HTMLInputElement>) => void
   options: Array<Pick<RadioButtonProps, 'label' | 'value' | 'disabled' | 'tooltipId'>>
   selectedValue?: string | number
+  defaultSelectedValue?: string | number
 }
 
 export function RadioButtonGroup({
@@ -33,6 +34,7 @@ export function RadioButtonGroup({
   onChange,
   options,
   selectedValue = '',
+  defaultSelectedValue = '',
   ...props
 }: RadioButtonGroupProps): ReactElement {
   const [value, setValue] = useState<string | number>(selectedValue)
@@ -57,6 +59,7 @@ export function RadioButtonGroup({
             key={optionProps.value}
             name={groupName}
             checked={optionProps.value === value}
+            defaultChecked={optionProps.value === defaultSelectedValue}
             onChange={optionOnChangeHandler}
             {...optionProps}
             disabled={disabled || optionProps.disabled}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
