### PR TITLE
feat: [SEI-9257]: Added callbacks to copy button

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.179.0",
+  "version": "3.180.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/CodeBlock/CodeBlock.test.tsx
+++ b/packages/uicore/src/components/CodeBlock/CodeBlock.test.tsx
@@ -7,7 +7,11 @@
 
 import React from 'react'
 import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { CodeBlock } from './CodeBlock'
+import copy from 'clipboard-copy'
+
+jest.mock('clipboard-copy', () => jest.fn())
 
 describe('Code Block', () => {
   test('should render with just snippet props', () => {
@@ -27,5 +31,17 @@ describe('Code Block', () => {
     const copybutton = document.querySelector('button')
     expect(copybutton).toBeDefined()
     expect(container).toMatchSnapshot()
+  })
+
+  test('should render codeblock with code copy and trigger onCopySuccess', async () => {
+    const onCopySuccess = jest.fn()
+    const copyContent = 'kubectl apply -f harness-delegate.yaml'
+    const { getByRole } = render(
+      <CodeBlock format="pre" allowCopy snippet={copyContent} onCopySuccess={onCopySuccess} />
+    )
+    const copyButton = getByRole('button')
+    await userEvent.click(copyButton)
+    expect(copy).toHaveBeenCalledWith(copyContent)
+    expect(onCopySuccess).toHaveBeenCalledWith(copyContent)
   })
 })

--- a/packages/uicore/src/components/CodeBlock/CodeBlock.test.tsx
+++ b/packages/uicore/src/components/CodeBlock/CodeBlock.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event'
 import { CodeBlock } from './CodeBlock'
 import copy from 'clipboard-copy'
 
-jest.mock('clipboard-copy', () => jest.fn())
+jest.mock('clipboard-copy', () => jest.fn(() => new Promise(resolve => resolve(null))))
 
 describe('Code Block', () => {
   test('should render with just snippet props', () => {

--- a/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
@@ -21,11 +21,10 @@ export interface CodeBlockProps {
   lineClamp?: number
   height?: number
   onCopySuccess?: (arg: string) => void
-  onCopyError?: (error: unknown) => void
 }
 
 export function CodeBlock(props: CodeBlockProps) {
-  const { snippet = '', allowCopy, codeToCopy, format = 'Text', lineClamp, height, onCopySuccess, onCopyError } = props
+  const { snippet = '', allowCopy, codeToCopy, format = 'Text', lineClamp, height, onCopySuccess } = props
 
   const floatButton = useMemo<boolean>(() => {
     return lineClamp !== 1 && snippet.split(/\n/).length >= 2
@@ -33,12 +32,9 @@ export function CodeBlock(props: CodeBlockProps) {
 
   const handleCopyButtonClick = useCallback(async () => {
     const copyContent = codeToCopy || snippet
-    try {
-      await Utils.copy(copyContent)
+    Utils.copy(copyContent).then(() => {
       onCopySuccess?.(copyContent)
-    } catch (e) {
-      onCopyError?.(e)
-    }
+    })
   }, [codeToCopy, snippet])
 
   return (

--- a/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
@@ -21,10 +21,11 @@ export interface CodeBlockProps {
   lineClamp?: number
   height?: number
   onCopySuccess?: (arg: string) => void
+  onCopyError?: (arg: unknown) => void
 }
 
 export function CodeBlock(props: CodeBlockProps) {
-  const { snippet = '', allowCopy, codeToCopy, format = 'Text', lineClamp, height, onCopySuccess } = props
+  const { snippet = '', allowCopy, codeToCopy, format = 'Text', lineClamp, height, onCopySuccess, onCopyError } = props
 
   const floatButton = useMemo<boolean>(() => {
     return lineClamp !== 1 && snippet.split(/\n/).length >= 2
@@ -32,9 +33,13 @@ export function CodeBlock(props: CodeBlockProps) {
 
   const handleCopyButtonClick = useCallback(async () => {
     const copyContent = codeToCopy || snippet
-    Utils.copy(copyContent).then(() => {
-      onCopySuccess?.(copyContent)
-    })
+    Utils.copy(copyContent)
+      .then(() => {
+        onCopySuccess?.(copyContent)
+      })
+      .catch((error: unknown) => {
+        onCopyError?.(error)
+      })
   }, [codeToCopy, snippet])
 
   return (

--- a/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Container } from '../Container/Container'
 import { Button } from '../Button/Button'
 import { Text } from '../Text/Text'
@@ -20,14 +20,26 @@ export interface CodeBlockProps {
   format?: string
   lineClamp?: number
   height?: number
+  onCopySuccess?: (arg: string) => void
+  onCopyError?: (error: unknown) => void
 }
 
 export function CodeBlock(props: CodeBlockProps) {
-  const { snippet = '', allowCopy, codeToCopy, format = 'Text', lineClamp, height } = props
+  const { snippet = '', allowCopy, codeToCopy, format = 'Text', lineClamp, height, onCopySuccess, onCopyError } = props
 
   const floatButton = useMemo<boolean>(() => {
     return lineClamp !== 1 && snippet.split(/\n/).length >= 2
   }, [lineClamp, snippet])
+
+  const handleCopyButtonClick = useCallback(async () => {
+    const copyContent = codeToCopy || snippet
+    try {
+      await Utils.copy(copyContent)
+      onCopySuccess?.(copyContent)
+    } catch (e) {
+      onCopyError?.(e)
+    }
+  }, [codeToCopy, snippet])
 
   return (
     <Container
@@ -53,7 +65,7 @@ export function CodeBlock(props: CodeBlockProps) {
         <Button
           icon="duplicate"
           minimal
-          onClick={() => Utils.copy(codeToCopy || snippet)}
+          onClick={handleCopyButtonClick}
           iconProps={{ size: 12 }}
           className={floatButton ? css.floatingCopyButton : undefined}
         />

--- a/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/uicore/src/components/CodeBlock/CodeBlock.tsx
@@ -33,13 +33,12 @@ export function CodeBlock(props: CodeBlockProps) {
 
   const handleCopyButtonClick = useCallback(async () => {
     const copyContent = codeToCopy || snippet
-    Utils.copy(copyContent)
-      .then(() => {
-        onCopySuccess?.(copyContent)
-      })
-      .catch((error: unknown) => {
-        onCopyError?.(error)
-      })
+    try {
+      await Utils.copy(copyContent)
+      onCopySuccess?.(copyContent)
+    } catch (e) {
+      onCopyError?.(e)
+    }
   }, [codeToCopy, snippet])
 
   return (


### PR DESCRIPTION
Description:
There are use cases where, after copying a snippet, we need to display a toast message to confirm the action. To support this functionality, I’ve added a callback to the copy button in the CodeBlock component.

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
