### PR TITLE
feat: [PL-57105]: add icon for custom banners

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/icons",
-  "version": "1.314.0",
+  "version": "1.315.0",
   "description": "Harness UICore - Lego for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/icons.umd.js",

--- a/packages/icons/src/HarnessIcons.ts
+++ b/packages/icons/src/HarnessIcons.ts
@@ -417,6 +417,7 @@ import CsHover from './cs-hover.svg'
 import CurrencyBanner from './currency-banner.svg'
 import CustomApproval from './custom-approval.svg'
 import CustomArtifact from './custom-artifact.svg'
+import CustomBanner from './custom-banner.svg'
 import CustomIngest from './custom-ingest.svg'
 import CustomPlugin from './custom-plugin.svg'
 import CustomRemoteManifest from './custom-remote-manifest.svg'
@@ -1880,6 +1881,7 @@ type HarnessIconName =
   | 'currency-banner'
   | 'custom-approval'
   | 'custom-artifact'
+  | 'custom-banner'
   | 'custom-ingest'
   | 'custom-plugin'
   | 'custom-remote-manifest'
@@ -3343,6 +3345,7 @@ const HarnessIcons: KVO<ElementType> = {
   'currency-banner': CurrencyBanner,
   'custom-approval': CustomApproval,
   'custom-artifact': CustomArtifact,
+  'custom-banner': CustomBanner,
   'custom-ingest': CustomIngest,
   'custom-plugin': CustomPlugin,
   'custom-remote-manifest': CustomRemoteManifest,

--- a/packages/icons/src/custom-banner.svg
+++ b/packages/icons/src/custom-banner.svg
@@ -1,0 +1,1 @@
+<svg width="32" height="33" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.5 4.981a1 1 0 0 0-1 1v21a1 1 0 0 0 1 1h23a1 1 0 0 0 1-1v-21a1 1 0 0 0-1-1h-23Zm0 1h23v2.772h-23V5.98Zm0 3.772h23V26.98h-23V9.753Z" fill="#0278D5"/><path d="M27.5 5.981h-23v2.772h23V5.98Z" fill="#0278D5"/></svg>


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

Added Custom banner icon from Figma ⬇️ 

<img width="1728" alt="Screenshot 2024-11-28 at 3 54 38 PM" src="https://github.com/user-attachments/assets/9600adbc-a207-4a18-822c-160fcc0b94d6">

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
