### PR TITLE
fix: [PIPE-20022]: Add support for tooltipProps for Select Component

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.182.1",
+  "version": "3.183.0",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/FormikForm/FormikForm.stories.tsx
+++ b/packages/uicore/src/components/FormikForm/FormikForm.stories.tsx
@@ -777,6 +777,10 @@ export const Basic: Story<FormikFormProps> = () => (
                 },
                 { label: 'Trying a long phrase with spaces to try out different combinations', value: 'abcd' }
               ]}
+              selectProps={{
+                addTooltip: true,
+                tooltipProps: { position: 'top' }
+              }}
             />
             <FormInput.MultiSelect
               name="colorMulti"

--- a/packages/uicore/src/components/Select/Select.stories.tsx
+++ b/packages/uicore/src/components/Select/Select.stories.tsx
@@ -85,6 +85,31 @@ export const SelectWithIcons: Story<SelectProps> = args => {
     </div>
   )
 }
+export const SelectWithIconsAndTooltip: Story<SelectProps> = args => {
+  const {
+    items = [
+      {
+        label: 'TryingTryingTryingTryingTryingTryingTryingTryingTrying',
+        value: 'service-kubernetes',
+        icon: { name: 'service-kubernetes' }
+      },
+      {
+        label: 'Trying a long phrase with spaces to try out different combinations',
+        value: 'service-github',
+        icon: { name: 'service-github' }
+      },
+      { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' } },
+      { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' } },
+      { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' } }
+    ]
+  } = args
+  const argsCopy = omit(args, ['size', 'items'])
+  return (
+    <div style={{ width: '300px', marginTop: 60 }}>
+      <Select items={items} addClearBtn={true} addTooltip={true} tooltipProps={{ position: 'top' }} {...argsCopy} />
+    </div>
+  )
+}
 SelectWithIcons.args = { size: SelectSize.Large }
 export const AsyncSelect: Story<SelectProps> = args => {
   interface SelectOption {

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -21,11 +21,11 @@ import { Position } from '@blueprintjs/core'
 import { Suggest, ISuggestProps, IItemRendererProps } from '@blueprintjs/select'
 import { OptionalTooltip } from '@harness/design-system'
 
-import css from './Select.css'
 import { Button } from '../../components/Button/Button'
 import { Icon, IconProps } from '@harness/icons'
 import { Utils } from '../../core/Utils'
 import { Text } from '../../components/Text/Text'
+import css from './Select.css'
 
 export interface SelectOption {
   label: string

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -19,13 +19,13 @@ import React, {
 import cx from 'classnames'
 import { Position } from '@blueprintjs/core'
 import { Suggest, ISuggestProps, IItemRendererProps } from '@blueprintjs/select'
+import { OptionalTooltip } from '@harness/design-system'
 
 import css from './Select.css'
 import { Button } from '../../components/Button/Button'
 import { Icon, IconProps } from '@harness/icons'
 import { Utils } from '../../core/Utils'
 import { Text } from '../../components/Text/Text'
-import { OptionalTooltip } from '@harness/design-system'
 
 export interface SelectOption {
   label: string

--- a/packages/uicore/src/core/Utils.tsx
+++ b/packages/uicore/src/core/Utils.tsx
@@ -60,7 +60,7 @@ interface WrapOptionalTooltipProps extends OptionalTooltip {
 }
 
 export function WrapOptionalTooltip({ tooltip, tooltipProps, children }: WrapOptionalTooltipProps): React.ReactElement {
-  const isDark = tooltipProps?.isDark
+  const { isDark = false, boundary = 'viewport', position = 'top', interactionKind = 'hover' } = tooltipProps ?? {}
   const content =
     typeof tooltip === 'string' ? (
       <div className={css.tooltipContainer} color={(isDark && 'white') || undefined}>
@@ -72,9 +72,9 @@ export function WrapOptionalTooltip({ tooltip, tooltipProps, children }: WrapOpt
 
   return tooltip ? (
     <Popover
-      boundary="viewport"
-      position="top"
-      interactionKind="hover"
+      boundary={boundary}
+      position={position}
+      interactionKind={interactionKind}
       {...tooltipProps}
       popoverClassName={cx(isDark ? Classes.DARK : undefined, tooltipProps?.popoverClassName)}
       content={content || ''}>


### PR DESCRIPTION
**Issue:** Select component always shows the tooltip if the `addTooltip` prop is true even if the selected item label element did not overflow.

**Fix:** Add tooltip when selected item label element overflow


**Before:**

https://github.com/user-attachments/assets/8d16fea0-05c4-42ba-b0e6-2d55b8d49831


**After:**

https://github.com/user-attachments/assets/284f0ea3-d6a6-44b5-9562-e939806665cf

**Uses in harness-core-ui:**


https://github.com/user-attachments/assets/f7f32350-70d5-4928-81bf-dba10b9f67af





You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
