### PR TITLE
fix: [PIPE-24105]: Warning: React does not recognize the  prop on a DOM element

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.182.0",
+  "version": "3.182.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
+++ b/packages/uicore/src/components/ModalDialog/ModalDialog.tsx
@@ -105,11 +105,11 @@ export const ModalDialog: FC<ModalDialogProps> = ({
       )}
 
       <ScrollShadowContainer
-        shadowTopAndBottomClassname={css.shadowTopAndBottom}
-        shadowTopClassname={css.shadowTop}
-        shadowBottomClassname={css.shadowBottom}
-        bodyClassname={css.body}
-        bodyContentClassname={css.bodyContent}
+        shadowTopAndBottomClassName={css.shadowTopAndBottom}
+        shadowTopClassName={css.shadowTop}
+        shadowBottomClassName={css.shadowBottom}
+        bodyClassName={css.body}
+        bodyContentClassName={css.bodyContent}
         data-testid="modaldialog-body">
         <div>{children}</div>
       </ScrollShadowContainer>

--- a/packages/uicore/src/components/ScrollShadowContainer/ScrollShadowContainer.tsx
+++ b/packages/uicore/src/components/ScrollShadowContainer/ScrollShadowContainer.tsx
@@ -6,28 +6,27 @@
  */
 
 import React, { HTMLAttributes, useCallback, useMemo, useRef, useState } from 'react'
-import { StyledProps, omitStyledProps, styledClasses } from '@harness/design-system'
-import { styledClass } from '@harness/design-system'
+import { StyledProps, omitStyledProps, styledClasses, styledClass } from '@harness/design-system'
 import { isFunction } from 'lodash-es'
 import css from './ScrollShadowContainer.module.css'
 import cx from 'classnames'
 
 export interface ScrollShadowContainerProps extends HTMLAttributes<HTMLDivElement>, StyledProps {
   tag?: keyof JSX.IntrinsicElements
-  shadowTopClassname?: string
-  shadowBottomClassname?: string
-  shadowTopAndBottomClassname?: string
-  bodyClassname?: string
-  bodyContentClassname?: string
+  shadowTopClassName?: string
+  shadowBottomClassName?: string
+  shadowTopAndBottomClassName?: string
+  bodyClassName?: string
+  bodyContentClassName?: string
 }
 
 function ScrollShadowContainer(props: ScrollShadowContainerProps): JSX.Element {
   const {
     tag = 'div',
     children,
-    shadowTopClassname = css.shadowTop,
-    shadowBottomClassname = css.shadowBottom,
-    shadowTopAndBottomClassname = css.shadowTopAndBottom
+    shadowTopClassName = css.shadowTop,
+    shadowBottomClassName = css.shadowBottom,
+    shadowTopAndBottomClassName = css.shadowTopAndBottom
   } = props
   const Tag = tag as React.ElementType
 
@@ -80,13 +79,13 @@ function ScrollShadowContainer(props: ScrollShadowContainerProps): JSX.Element {
     const { top, bottom } = scrollShadows
 
     if (top && bottom) {
-      return shadowTopAndBottomClassname
+      return shadowTopAndBottomClassName
     }
     if (top) {
-      return shadowTopClassname
+      return shadowTopClassName
     }
     if (bottom) {
-      return shadowBottomClassname
+      return shadowBottomClassName
     }
     return ''
   }, [scrollShadows])
@@ -94,9 +93,9 @@ function ScrollShadowContainer(props: ScrollShadowContainerProps): JSX.Element {
   return (
     <Tag
       {...omitStyledProps(props)}
-      className={cx(styledClasses(props, styledClass.font), bodyShadowClass, css.body, props.bodyClassname)}
+      className={cx(styledClasses(props, styledClass.font), bodyShadowClass, css.body, props.bodyClassName)}
       ref={bodyRefCallback}>
-      <div className={cx(css.bodyContent, props.bodyContentClassname)}>
+      <div className={cx(css.bodyContent, props.bodyContentClassName)}>
         <div ref={bodyTopEdgeRef} data-position="top" />
         {children}
         <div ref={bodyBottomEdgeRef} data-position="bottom" />

--- a/packages/uicore/src/components/Text/Text.css
+++ b/packages/uicore/src/components/Text/Text.css
@@ -24,3 +24,11 @@
 .icon {
   vertical-align: middle;
 }
+
+.tooltip {
+  max-width: 600px;
+}
+
+.tooltipWrapper {
+  display: inline-flex;
+}

--- a/packages/uicore/src/components/Text/Text.stories.tsx
+++ b/packages/uicore/src/components/Text/Text.stories.tsx
@@ -10,6 +10,7 @@ import type { Meta, Story } from '@storybook/react'
 import { Title, Subtitle, ArgsTable, Stories, PRIMARY_STORY, Primary, Description } from '@storybook/addon-docs/blocks'
 import { Text, TextProps, Layout, Container, SupText } from '../..'
 import { FontVariation, Color } from '@harness/design-system'
+import css from './Text.css'
 
 export default {
   title: 'Components / Text',
@@ -54,6 +55,23 @@ export default {
 export const Basic: Story<TextProps> = () => {
   return (
     <>
+      <Text
+        inline
+        icon="full-circle"
+        iconProps={{ size: 6, color: 'green' }}
+        tooltip={
+          <Text font={{ variation: FontVariation.FORM_MESSAGE_SUCCESS }}>
+            RandomLongName RandomLongName RandomLongNameRandomLongNameRandomLongNameRandomLongName
+          </Text>
+        }
+        tooltipProps={{
+          isDark: true,
+          position: 'bottom',
+          popoverClassName: css.tooltip,
+          className: css.tooltipWrapper
+        }}>
+        RandomLongName Form Message Success
+      </Text>
       <Text
         font={{ variation: FontVariation.DISPLAY1 }}
         tooltip={`<Text font={{ variation: FontVariation.DISPLAY1 }}>Display 1</Text>`}>


### PR DESCRIPTION
**Issue:** React giving `Warning: React does not recognize the `bodyContentClassname` prop on a DOM element.`
**Fix:** Update class names props for ScrollShadowContainerProps to camelCase

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
