### PR TITLE
fix: [PIPE-20022]: Fix MultiTypeInput Select value field with overlap label

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.183.0",
+  "version": "3.183.1",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/CategorizedSelected/CategorizedSelect.stories.tsx
+++ b/packages/uicore/src/components/CategorizedSelected/CategorizedSelect.stories.tsx
@@ -45,15 +45,17 @@ export default {
   decorators: [Story => <Story />]
 } as Meta
 export const Basic: Story<CategorizedSelectProps> = args => {
+  const longLabel = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry'
   const {
     items = [
       { label: 'Squirtle', value: 'squirtle', category: 'Water' },
       { label: 'Charizard', value: 'charizard', category: 'Fire' },
       { label: 'Venosaur', value: 'venosaur', category: 'Grass' },
       { label: 'Typhlosion', value: 'typhlosion', category: 'Fire' },
-      { label: 'Feraligatr', value: 'feraligator', category: 'Water' }
+      { label: 'Feraligatr', value: 'feraligator', category: 'Water' },
+      { label: longLabel, value: longLabel, category: 'Water' }
     ]
   } = args
   const argsCopy = omit(args, ['items'])
-  return <CategorizedSelect items={items} {...argsCopy} />
+  return <CategorizedSelect items={items} {...argsCopy} selectProps={{ addTooltip: true }} />
 }

--- a/packages/uicore/src/components/FieldArray/Examples/FieldArrayExample.tsx
+++ b/packages/uicore/src/components/FieldArray/Examples/FieldArrayExample.tsx
@@ -65,6 +65,8 @@ export default function FieldArrayExample() {
     }
   ]
 
+  const longLabel = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry'
+
   const fields2: Field[] = [
     {
       name: 'name',
@@ -81,8 +83,10 @@ export default function FieldArrayExample() {
         <Select
           items={[
             { label: 'Text', value: 'TEXT' },
-            { label: 'Encrypted Text', value: 'ENCRYPTED_TEXT' }
+            { label: 'Encrypted Text', value: 'ENCRYPTED_TEXT' },
+            { label: longLabel, value: longLabel }
           ]}
+          addTooltip
           value={value}
           onChange={handleChange}
         />

--- a/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
+++ b/packages/uicore/src/components/ListHeader/ListHeader.stories.tsx
@@ -25,6 +25,7 @@ import css from './ListHeaderStory.css'
 import cx from 'classnames'
 import { noop } from 'lodash-es'
 
+const longLabel = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry'
 const selectOptions = [
   {
     label: 'Service Kubernetes',
@@ -38,7 +39,8 @@ const selectOptions = [
   },
   { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' as IconName } },
   { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' as IconName } },
-  { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' as IconName } }
+  { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' as IconName } },
+  { label: longLabel, value: longLabel, icon: { name: 'service-gcp' as IconName } }
 ]
 
 export default {
@@ -100,7 +102,7 @@ export const ListHeaderWithPreDropdownContent: Story<ListHeaderProps> = () => {
       onSortMethodChange={noop}
       preDropdownContent={
         <div className={cx(css.selectWrapper, css.selectWrapperPre)}>
-          <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+          <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} addTooltip />
         </div>
       }
       className={cx(css.listHeaderStory)}
@@ -118,7 +120,7 @@ export const ListHeaderWithPostDropdownContent: Story<ListHeaderProps> = () => {
       postDropdownContent={
         <div>
           <div className={cx(css.selectWrapper, css.selectWrapperPost)}>
-            <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+            <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} addTooltip />
           </div>
         </div>
       }
@@ -136,13 +138,19 @@ export const ListHeaderWithPreAndPostDropdownContent: Story<ListHeaderProps> = (
       onSortMethodChange={noop}
       preDropdownContent={
         <div className={cx(css.selectWrapper, css.selectWrapperPre)}>
-          <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+          <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} addTooltip />
         </div>
       }
       postDropdownContent={
         <div>
           <div className={cx(css.selectWrapper, css.selectWrapperPost)}>
-            <Select items={selectOptions} addClearBtn={true} value={selectOptions[1]} />
+            <Select
+              items={selectOptions}
+              addClearBtn={true}
+              value={selectOptions[1]}
+              addTooltip
+              tooltipProps={{ position: 'top' }}
+            />
           </div>
         </div>
       }

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.stories.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.stories.tsx
@@ -57,10 +57,20 @@ TextInput.args = {
   ]
 }
 
+const longLabel =
+  "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged"
+
 SelectInput.args = {
   selectProps: {
-    items: data.slice(0, 10).map(row => ({ label: row.name, value: row.id })),
-    addClearBtn: true
+    items: [
+      ...data.slice(0, 10).map(row => ({ label: row.name, value: row.id })),
+      {
+        label: longLabel,
+        value: longLabel
+      }
+    ],
+    addClearBtn: true,
+    addTooltip: true
   },
   disabled: false,
   expressionPlaceHolder: '<+test.app>',

--- a/packages/uicore/src/components/Select/Select.css
+++ b/packages/uicore/src/components/Select/Select.css
@@ -177,3 +177,7 @@
   color: var(--grey-500);
   padding: 8px 0px 0px 7px;
 }
+
+.target {
+  width: 100%;
+}

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -359,7 +359,8 @@ export function Select(props: SelectProps): ReactElement {
         ...tooltipProps,
         targetTagName: tooltipProps?.targetTagName || 'div',
         position: tooltipProps?.position || 'bottom',
-        targetClassName: cx(tooltipProps?.targetClassName)
+        targetClassName: cx(tooltipProps?.targetClassName),
+        className: cx(css.target)
       }}>
       {renderSuggestComponent()}
     </Utils.WrapOptionalTooltip>

--- a/packages/uicore/src/components/SelectWithSubview/SelectWithSubView.stories.tsx
+++ b/packages/uicore/src/components/SelectWithSubview/SelectWithSubView.stories.tsx
@@ -108,9 +108,12 @@ export const Basic: Story<SelectWithSubviewProps> = args => {
     envType: EnvTypes.PROD
   }
 
+  const longLabel =
+    "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
   const ExampleItems: SelectOption[] = [
     { value: 'env_id1', label: 'Env1' },
-    { value: 'env_id2', label: 'Env2' }
+    { value: 'env_id2', label: 'Env2' },
+    { value: longLabel, label: longLabel }
   ]
 
   function validateForm(values: EnvironmentTypeFormData): FormikErrors<EnvironmentTypeFormData> {
@@ -212,6 +215,7 @@ export const Basic: Story<SelectWithSubviewProps> = args => {
             items={items}
             changeViewButtonLabel={changeViewButtonLabel}
             subview={subview}
+            addTooltip
             {...argsCopy}
           />
         </Form>

--- a/packages/uicore/src/components/Table/Table.stories.tsx
+++ b/packages/uicore/src/components/Table/Table.stories.tsx
@@ -101,12 +101,16 @@ export const WithCustomRowRenderer: Story<TableProps<any>> = args => {
       return cell.value
     }
 
+    const longLabel = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.'
+
     return (
       <Select
         items={[
           { value: 'service1_uuid', label: 'service1' },
-          { value: 'service1_uuid', label: 'service2' }
+          { value: 'service1_uuid', label: 'service2' },
+          { value: longLabel, label: longLabel }
         ]}
+        addTooltip
       />
     )
   }


### PR DESCRIPTION
**Before:**
<img width="1728" alt="Screenshot 2024-12-16 at 11 31 40 PM" src="https://github.com/user-attachments/assets/95fde725-51d0-44c6-a407-345e7083403e" />


**After:**
<img width="1721" alt="Screenshot 2024-12-16 at 11 31 02 PM" src="https://github.com/user-attachments/assets/c566001a-c065-4b61-acd0-895f66af0f8b" />

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
