### PR TITLE
fix: [PIPE-20022]: Fix MultiTypeInput Select value field with overlap label

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.183.1",
+  "version": "3.183.2",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.stories.tsx
+++ b/packages/uicore/src/components/MultiTypeInput/MultiTypeInput.stories.tsx
@@ -74,7 +74,7 @@ SelectInput.args = {
   },
   disabled: false,
   expressionPlaceHolder: '<+test.app>',
-  value: { label: data[0].name, value: data[0].id },
+  value: { label: longLabel, value: longLabel },
   expressions: [
     'app.name',
     'app.description',

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -183,9 +183,7 @@ export function Select(props: SelectProps): ReactElement {
     setSelectedItem(item)
   }
 
-  function onPopoverClosed(node: HTMLElement): void {
-    whenPopoverClosed?.(node)
-
+  function handleInputValueScroll() {
     if (inputRef.current) {
       const element = inputRef.current
       const widthDifference = (element.scrollWidth || 0) - (element.offsetWidth || 0)
@@ -194,6 +192,12 @@ export function Select(props: SelectProps): ReactElement {
     } else {
       setIsScrollable(false)
     }
+  }
+
+  function onPopoverClosed(node: HTMLElement): void {
+    whenPopoverClosed?.(node)
+
+    handleInputValueScroll()
   }
 
   useEffect(() => {
@@ -255,6 +259,11 @@ export function Select(props: SelectProps): ReactElement {
   const inputRefCallback = useCallback((el: HTMLInputElement | null) => {
     inputRef.current = el
   }, [])
+
+  // This effect is to handle the case when initial selected value is itself overflowing
+  useEffect(() => {
+    handleInputValueScroll()
+  }, [inputRef.current])
 
   useEffect(() => {
     if (addTooltip) {


### PR DESCRIPTION
**Issue:** The Tooltip was not coming for the select component if the initial value overlapped.
<img width="1171" alt="Screenshot 2024-12-17 at 12 18 04 AM" src="https://github.com/user-attachments/assets/a91b86bf-2384-40b9-b989-c490106810ba" />


**Fix:** Check for value overlap on component render.
<img width="1169" alt="Screenshot 2024-12-17 at 12 17 34 AM" src="https://github.com/user-attachments/assets/2d707c1c-96f8-4413-b0eb-63dcd85101fc" />

You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`

