### PR TITLE
fix: [PIPE-23362]: Show tooltip for the select when selected value change

### DIFF
--- a/packages/uicore/package.json
+++ b/packages/uicore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/uicore",
-  "version": "3.183.2",
+  "version": "3.183.3",
   "description": "Harness UICore - Legos for building Harness UI applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/uicore/src/components/Select/Select.stories.tsx
+++ b/packages/uicore/src/components/Select/Select.stories.tsx
@@ -86,27 +86,39 @@ export const SelectWithIcons: Story<SelectProps> = args => {
   )
 }
 export const SelectWithIconsAndTooltip: Story<SelectProps> = args => {
-  const {
-    items = [
-      {
-        label: 'TryingTryingTryingTryingTryingTryingTryingTryingTrying',
-        value: 'service-kubernetes',
-        icon: { name: 'service-kubernetes' }
-      },
-      {
-        label: 'Trying a long phrase with spaces to try out different combinations',
-        value: 'service-github',
-        icon: { name: 'service-github' }
-      },
-      { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' } },
-      { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' } },
-      { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' } }
-    ]
-  } = args
+  const items: SelectOption[] = [
+    {
+      label: 'TryingTryingTryingTryingTryingTryingTryingTryingTrying',
+      value: 'service-kubernetes',
+      icon: { name: 'service-kubernetes' }
+    },
+    {
+      label: 'Trying a long phrase with spaces to try out different combinations',
+      value: 'service-github',
+      icon: { name: 'service-github' }
+    },
+    { label: 'ELK', value: 'service-elk', icon: { name: 'service-elk' } },
+    { label: 'Jenkins', value: 'service-jenkins', icon: { name: 'service-jenkins' } },
+    { label: 'GCP', value: 'service-gcp', icon: { name: 'service-gcp' } }
+  ]
+
+  const [selectedValue, setSelectedValue] = useState(items[2])
   const argsCopy = omit(args, ['size', 'items'])
+
+  setTimeout(() => {
+    setSelectedValue(items[1])
+  }, 100)
+
   return (
     <div style={{ width: '300px', marginTop: 60 }}>
-      <Select items={items} addClearBtn={true} addTooltip={true} tooltipProps={{ position: 'top' }} {...argsCopy} />
+      <Select
+        items={items}
+        value={selectedValue}
+        addClearBtn={true}
+        addTooltip={true}
+        tooltipProps={{ position: 'top' }}
+        {...argsCopy}
+      />
     </div>
   )
 }

--- a/packages/uicore/src/components/Select/Select.tsx
+++ b/packages/uicore/src/components/Select/Select.tsx
@@ -186,7 +186,7 @@ export function Select(props: SelectProps): ReactElement {
   function handleInputValueScroll() {
     if (inputRef.current) {
       const element = inputRef.current
-      const widthDifference = (element.scrollWidth || 0) - (element.offsetWidth || 0)
+      const widthDifference = (element.scrollWidth || 0) - (element.getBoundingClientRect().width || 0)
 
       setIsScrollable(widthDifference > 1)
     } else {
@@ -260,10 +260,12 @@ export function Select(props: SelectProps): ReactElement {
     inputRef.current = el
   }, [])
 
-  // This effect is to handle the case when initial selected value is itself overflowing
+  /**
+   * Calculate isScrollable on initial render and when value changes
+   */
   useEffect(() => {
     handleInputValueScroll()
-  }, [inputRef.current])
+  }, [inputRef.current, value])
 
   useEffect(() => {
     if (addTooltip) {


### PR DESCRIPTION
**Before:**: Tooltip is not shown when selected value is updated

https://github.com/user-attachments/assets/094f4e66-e061-4b86-a09d-ca4382c2129d



**After:** Tootip shown when selected value change

https://github.com/user-attachments/assets/4accccae-5df8-499a-b010-c7bf90263e16

**Uses in harness-core-ui:**

https://github.com/user-attachments/assets/ca5d3ea6-87f0-49d0-b185-cce1241b25ea





You can use the following comments to re-trigger PR Checks

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- StyleLint: `retrigger stylelint`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- ImageSnapshot `retrigger ImageSnapshot`
